### PR TITLE
Workflows for basic pathogen repo CI

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -1,0 +1,38 @@
+# This workflow is intended to be called by workflows in our various pathogen
+# build repos.  See workflow-templates/pathogen-repo-ci.yaml (a "starter"
+# workflow) in this repo for an example of what the caller workflow looks like.
+name: CI
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v3
+        with:
+          # Consider parameterizing the Python version. -trs, 1 April 2022
+          python-version: "3.7"
+
+      - run: python3 -m pip install --upgrade pip setuptools wheel
+      - run: python3 -m pip install nextstrain-cli
+      - run: nextstrain version
+      - run: nextstrain check-setup
+      - run: nextstrain update
+
+      # Consider conditionalizing the copy from example_data/ on its existence
+      # and assume that if it's missing the calling workflow will setup any
+      # data appropriately first.  Update filePatterns in
+      # workflow-templates/pathogen-repo-ci.properties.json if we do.
+      #   -trs, 1 April 2022
+      - name: Copy example data
+        run: |
+          mkdir -p data/
+          cp -v example_data/* data/
+
+      # Consider parameterizing additional arguments here in the future to
+      # support more complex CI builds.
+      #   -trs, 1 April 2022
+      - run: nextstrain build --docker .

--- a/workflow-templates/pathogen-repo-ci.properties.json
+++ b/workflow-templates/pathogen-repo-ci.properties.json
@@ -1,0 +1,8 @@
+{
+  "name": "CI for pathogen repos",
+  "description": "Basic CI workflow for repos housing Nextstrain pathogen builds",
+  "filePatterns": [
+    "^Snakefile$",
+    "^example_data$"
+  ]
+}

--- a/workflow-templates/pathogen-repo-ci.yaml
+++ b/workflow-templates/pathogen-repo-ci.yaml
@@ -1,0 +1,9 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master


### PR DESCRIPTION
The goal is to establish a common setup for CI for all or at least most
of our pathogen build repos.

Includes a reusable workflow¹ which can be called/invoked by our
workflows in other repos and a "starter" workflow template² that
performs such a call, for copying into the pathogen repo (either
manually or via the web UI which supports these starter workflows).

These are both basic for now but appropriate for our "simple" pathogen
builds like zika and measles.  We can add workflow parameters and
conditionals as necessary in the future to support CI for more complex
builds, like ncov.  (It won't take much!)

Related to <https://github.com/nextstrain/zika/pull/16>.

¹ https://docs.github.com/en/actions/using-workflows/reusing-workflows
² https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization
