### PR TITLE
Parameterize pathogen repo CI with optional additional `nextstrain build` args

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -5,6 +5,14 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      build-args:
+        description: >-
+          Additional command-line arguments to pass to `nextstrain build` after
+          the build directory (e.g. to Snakemake).
+        type: string
+        default: ""
+        required: false
 
 jobs:
   build:
@@ -32,7 +40,4 @@ jobs:
           mkdir -p data/
           cp -v example_data/* data/
 
-      # Consider parameterizing additional arguments here in the future to
-      # support more complex CI builds.
-      #   -trs, 1 April 2022
-      - run: nextstrain build --docker .
+      - run: nextstrain build --docker . ${{ inputs.build-args }}


### PR DESCRIPTION
Additional build args are needed for avian-flu and seasonal-flu repos.

### Related issue(s)
Related to https://github.com/nextstrain/avian-flu/pull/8 and https://github.com/nextstrain/seasonal-flu/pull/80