### PR TITLE
Upload auspice/, results/, and Snakemake logs from pathogen repo CI runs to artifact storage

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -73,4 +73,6 @@ jobs:
           path: |
             auspice/
             results/
+            benchmarks/
+            logs/
             .snakemake/log/

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -66,3 +66,11 @@ jobs:
           fi
 
       - run: nextstrain build --docker . ${{ inputs.build-args }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: outputs
+          path: |
+            auspice/
+            results/
+            .snakemake/log/


### PR DESCRIPTION
Seems likely to be useful at times for debugging why a CI run failed.

### Testing
Based on #18 so I can see it run in this repo's CI before merge. [Update: …and glad I did, as it caught a typo!]

- [x] Successful artifact upload in CI ([example run](https://github.com/nextstrain/.github/actions/runs/2241384419), see "outputs" at bottom)