### PR TITLE
pathogen-repo-ci: Make example_data/ optional

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,14 @@ on:
   - pull_request
 
 jobs:
-  test:
+  test-setup-nextstrain-cli:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./actions/setup-nextstrain-cli
       - run: nextstrain version --verbose
+
+  test-pathogen-repo-ci:
+    uses: ./.github/workflows/pathogen-repo-ci.yaml
+    with:
+      repo: nextstrain/zika

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,3 +16,8 @@ jobs:
     uses: ./.github/workflows/pathogen-repo-ci.yaml
     with:
       repo: nextstrain/zika
+
+  test-pathogen-repo-ci-no-example-data:
+    uses: ./.github/workflows/pathogen-repo-ci.yaml
+    with:
+      repo: nextstrain/zika-tutorial

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -14,11 +14,22 @@ on:
         default: ""
         required: false
 
+      repo:
+        description: >-
+          Repository name with owner (e.g. nextstrain/zika).  Defaults to the
+          repository of the caller workflow.
+        type: string
+        default: ${{ github.repository }}
+        required: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repo }}
+
       - uses: actions/setup-python@v3
         with:
           # Consider parameterizing the Python version. -trs, 1 April 2022

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -41,14 +41,13 @@ jobs:
       - run: nextstrain check-setup
       - run: nextstrain update
 
-      # Consider conditionalizing the copy from example_data/ on its existence
-      # and assume that if it's missing the calling workflow will setup any
-      # data appropriately first.  Update filePatterns in
-      # workflow-templates/pathogen-repo-ci.properties.json if we do.
-      #   -trs, 1 April 2022
       - name: Copy example data
         run: |
-          mkdir -p data/
-          cp -v example_data/* data/
+          if [[ -d example_data ]]; then
+            mkdir -p data/
+            cp -v example_data/* data/
+          else
+            echo No example data to copy.
+          fi
 
       - run: nextstrain build --docker . ${{ inputs.build-args }}

--- a/workflow-templates/pathogen-repo-ci.properties.json
+++ b/workflow-templates/pathogen-repo-ci.properties.json
@@ -2,7 +2,6 @@
   "name": "CI for pathogen repos",
   "description": "Basic CI workflow for repos housing Nextstrain pathogen builds",
   "filePatterns": [
-    "^Snakefile$",
-    "^example_data$"
+    "^Snakefile$"
   ]
 }


### PR DESCRIPTION
### Description of proposed changes

Assume that if it's missing there's no data setup to do.  Lets us use
this workflow for the ncov repo, which doesn't use example_data/.

### Related issue(s)
Related to …

### Testing
- [x] CI passes for PR