### PR TITLE
Workflows for Sphinx docs CI

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -1,0 +1,47 @@
+# This workflow is intended to be called by workflows in our various software
+# repos containing Sphinx documentation projects.
+# See workflow-templates/docs-ci.yaml (a "starter" workflow) in this repo for
+# an example of what the caller workflow looks like.
+name: Sphinx docs CI
+
+on:
+  workflow_call:
+    inputs:
+      docs-directory:
+        description: >-
+          Directory containing Makefile. (e.g. docs/)
+        type: string
+        required: true
+
+      environment-file:
+        description: >-
+          Path to conda environment file (e.g. docs/conda.yml)
+        type: string
+        required: true
+
+      make-target:
+        description: >-
+          Sphinx builder name. See https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options
+        type: string
+        default: html
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        environment-file: ${{ inputs.environment-file }}
+    - run: conda list
+    - run: make ${{ inputs.make-target }}
+      working-directory: ${{ inputs.docs-directory }}
+      env:
+        # https://www.sphinx-doc.org/en/master/man/sphinx-build.html
+        # -n: warn on missing references
+        # -W: error on warnings
+        # --keep-going: find all warnings
+        SPHINXOPTS: -n -W --keep-going

--- a/workflow-templates/docs-ci.properties.json
+++ b/workflow-templates/docs-ci.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "CI for Sphinx docs",
+  "description": "Basic CI workflow for repos containing a Sphinx documentation project"
+}

--- a/workflow-templates/docs-ci.yaml
+++ b/workflow-templates/docs-ci.yaml
@@ -1,0 +1,9 @@
+name: Sphinx docs CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  ci:
+    uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master

--- a/workflow-templates/pathogen-repo-ci.yaml
+++ b/workflow-templates/pathogen-repo-ci.yaml
@@ -7,3 +7,6 @@ on:
 jobs:
   ci:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    with:
+      docs-directory: docs/
+      environment-file: docs/conda.yml


### PR DESCRIPTION
### Description of proposed changes

This parallels the motivation behind 6245d9e4d031a244d32979e4a27c6badcb503854 for pathogen repo CI, but for repos containing Sphinx documentation.

As a starting point, the reusable workflow fails on build warnings such as invalid links and bad formatting.

### Related issue(s)

_N/A_

### Testing

See nextstrain/ncov#941