### PR TITLE
Fix workflow-templates mixup between docs-ci and pathogen-repo-ci

### DIFF
--- a/workflow-templates/docs-ci.yaml
+++ b/workflow-templates/docs-ci.yaml
@@ -7,3 +7,6 @@ on:
 jobs:
   ci:
     uses: nextstrain/.github/.github/workflows/docs-ci.yaml@master
+    with:
+      docs-directory: docs/
+      environment-file: docs/conda.yml

--- a/workflow-templates/pathogen-repo-ci.yaml
+++ b/workflow-templates/pathogen-repo-ci.yaml
@@ -7,6 +7,3 @@ on:
 jobs:
   ci:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
-    with:
-      docs-directory: docs/
-      environment-file: docs/conda.yml


### PR DESCRIPTION
The "with" parameter block was added to the wrong file in "Workflows for
Sphinx docs CI" (a65c1b2).

### Related issue(s)
Related to #20.
