### PR TITLE
pathogen-repo-ci: Allow caller to pass env vars

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -22,10 +22,42 @@ on:
         default: ${{ github.repository }}
         required: false
 
+      env:
+        description: >-
+          Additional environment variables to set before the build, as a string
+          containing YAML.  This is easily produced, for example, by pretending
+          you're writing normal nested YAML within a literal multi-line block
+          scalar (introduced by "|"):
+
+            with:
+              env: |
+                FOO: bar
+                I_CANT_BELIEVE: "it's not YAML"
+
+          Do not use for secrets!  Instead, pass them via GitHub Action's
+          dedicated secrets mechanism.
+        type: string
+        default: ""
+        required: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - if: inputs.env
+        name: Set environment variables
+        env:
+          env: ${{ inputs.env }}
+        run: >
+          echo "$env"
+          | yq --output-format json .
+          | jq --raw-output '
+              to_entries
+            | map("\(.key)<<__EOF__\n\(.value)\n__EOF__")
+            | join("\n")
+          '
+          | tee -a "$GITHUB_ENV"
+
       - uses: actions/checkout@v3
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -33,6 +33,10 @@ on:
               env: |
                 FOO: bar
                 I_CANT_BELIEVE: "it's not YAML"
+                would_you_believe: |
+                  it's
+                  not
+                  yaml
 
           Do not use for secrets!  Instead, pass them via GitHub Action's
           dedicated secrets mechanism.
@@ -44,6 +48,44 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Transforms the inputs.env *string* containing YAML like this:
+      #
+      #   FOO: bar
+      #   I_CANT_BELIEVE: "it's not YAML"
+      #   would_you_believe: |
+      #     it's
+      #     not
+      #     yaml
+      #
+      # first into the equivalent JSON (with yq) and then into text (with jq)
+      # like this:
+      #
+      #   FOO=<<__EOF__
+      #   bar
+      #   __EOF__
+      #   I_CANT_BELIEVE<<__EOF__
+      #   it's not YAML
+      #   __EOF__
+      #   would_you_believe<<__EOF__
+      #   it's
+      #   not
+      #   yaml
+      #   __EOF__
+      #
+      # which is suitable for appending to the $GITHUB_ENV file in order to set
+      # the environment variables for subsequent steps.
+      #
+      # See the GitHub docs for more info on this heredoc-like syntax¹, which I
+      # use here to avoid quoting issues in arbitrary env var values.
+      #
+      # By doing this slightly-convoluted conversion here, callers can use the
+      # familiar env: block syntax almost without change and avoid paying much
+      # in accidental complexity.  We box it up here and let callers focus on
+      # their essential complexity.
+      #   -trs, 23 May 2022
+      #
+      # ¹ https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+      #
       - if: inputs.env
         name: Set environment variables
         env:


### PR DESCRIPTION
This can be useful to set variables respected by Augur, Nextstrain CLI,
etc.  Implemented ourselves as a workflow input since the usual job.env
block is not (yet?) supported by GitHub Actions for jobs which call a
reusable workflow.

The input value is a YAML-formatted string, which you can easily produce
by pretending you're writing normal nested YAML within a literal
multi-line block scalar (introduced by "|"):

```yaml
   with:
     env: |
       FOO: bar
       I_CANT_BELIEVE: "it's not YAML"
```

When (if?) the usual job.env block is supported for reusable workflows,
it will be a small transformation for each caller to use it.

### Testing
Tested in a separate GitHub Actions testbed, though I may have mucked up the syntax in this particular file. We'll see when I try to use it!

Update: Usage in https://github.com/nextstrain/monkeypox/pull/8 found a small place I mucked up, which is now fixed and that PR's CI ran successfully.