### PR TITLE
pathogen-repo-ci: Always upload outputs even on failure

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -141,7 +141,8 @@ jobs:
 
       - run: nextstrain build --docker . ${{ inputs.build-args }}
 
-      - uses: actions/upload-artifact@v3
+      - if: always()
+        uses: actions/upload-artifact@v3
         with:
           name: outputs
           path: |


### PR DESCRIPTION
Helpful for debugging.  Suggested here by @corneliusroemer.  Based on
similar logic I made for nextstrain.org CI.¹

¹ https://github.com/nextstrain/nextstrain.org/commit/017f1239

### Testing
- [x] CI passes?