### PR TITLE
docs-ci: Add pip install option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,19 @@ jobs:
     with:
       repo: nextstrain/zika-tutorial
 
-  test-docs-ci:
+  test-docs-ci-conda:
     uses: ./.github/workflows/docs-ci.yaml
     with:
       repo: nextstrain/docs.nextstrain.org
       docs-directory: .
       environment-file: environment.yml
+
+  test-docs-ci-pip:
+    uses: ./.github/workflows/docs-ci.yaml
+    with:
+      repo: nextstrain/augur
+      docs-directory: docs/
+      pip-install-target: .[dev]
 
   test-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -23,9 +23,15 @@ on:
 
       environment-file:
         description: >-
-          Path to conda environment file (e.g. docs/conda.yml)
+          Path to conda environment file. (e.g. docs/conda.yml)
         type: string
-        required: true
+        required: false
+
+      pip-install-target:
+        description: >-
+          Pip install target. (e.g. local directory which contains setup.py, project URL)
+        type: string
+        required: false
 
       make-target:
         description: >-
@@ -33,8 +39,17 @@ on:
         type: string
         default: html
 
+env:
+  # Used for `make` steps.
+  # -n: warn on missing references
+  # -W: error on warnings
+  # --keep-going: find all warnings
+  # https://www.sphinx-doc.org/en/master/man/sphinx-build.html
+  SPHINXOPTS: -n -W --keep-going
+
 jobs:
-  build:
+  build-conda:
+    if: inputs.environment-file != ''
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -52,9 +67,18 @@ jobs:
 
       - run: make ${{ inputs.make-target }}
         working-directory: ${{ inputs.docs-directory }}
-        env:
-          # https://www.sphinx-doc.org/en/master/man/sphinx-build.html
-          # -n: warn on missing references
-          # -W: error on warnings
-          # --keep-going: find all warnings
-          SPHINXOPTS: -n -W --keep-going
+
+  build-pip:
+    if: inputs.pip-install-target != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repo }}
+
+      - run: pip install '${{ inputs.pip-install-target }}'
+
+      - run: pip list
+
+      - run: make ${{ inputs.make-target }}
+        working-directory: ${{ inputs.docs-directory }}


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Some docs projects use pip instead of conda to set up the environment.

1. Make environment-file input (Conda setup) optional.

2. Add a new optional input to install from pip.

3. Use one job per environment setup option.

Specifying none of the setup options will cause both jobs to be skipped, but I think that's appropriate user error.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Closes #21 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Jobs run as expected ([evidence](https://github.com/nextstrain/.github/actions/runs/3624983828), though note that the warnings do not result in an error since https://github.com/nextstrain/augur/commit/b0b8abc48706a71cd8edf4d53fb6a3999e2d2ef3 has yet to be applied)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
