### PR TITLE
sync-rtd-redirects: Perform dry runs when not on the default branch

### DIFF
--- a/.github/workflows/sync-rtd-redirects.yaml
+++ b/.github/workflows/sync-rtd-redirects.yaml
@@ -40,7 +40,15 @@ jobs:
       - name: Install readthedocs-cli
         run: python3 -m pip install readthedocs-cli
 
-      - name: Sync redirects
+      - if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        id: wet-run
+        name: Sync redirects
         run: rtd projects "${{ inputs.project }}" redirects sync -f "${{ inputs.file }}" --wet-run
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+
+      - if: steps.wet-run.conclusion == 'skipped'
+        name: Sync redirects (DRY RUN)
+        run: rtd projects "${{ inputs.project }}" redirects sync -f "${{ inputs.file }}" --dry-run
         env:
           RTD_TOKEN: ${{ secrets.RTD_TOKEN }}

--- a/workflow-templates/sync-rtd-redirects.yaml
+++ b/workflow-templates/sync-rtd-redirects.yaml
@@ -27,6 +27,11 @@ on:
       - doc/redirects.yaml
       - .github/workflows/sync-rtd-redirects.yaml
 
+  # The reusable workflow will only actually make changes when running on the
+  # default branch (e.g. refs/heads/main); every other run will be a dry run.
+  # If you don't want dry runs on PRs, then remove this trigger.
+  pull_request:
+
   # Manually triggered using GitHub's UI
   workflow_dispatch:
 


### PR DESCRIPTION
This accomplishes two important things:

1. It protects against misconfigurations of the calling workflow's triggers, e.g. previously if the calling workflow included "pull_request" events then syncs would happen when they shouldn't have because triggers were trusted to be correct.

2. It makes this workflow useful for PRs by previewing the changes that will happen upon merge.

### Related issue(s)

#30 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Manually test from calling workflow

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
