### PR TITLE
sync-rtd-redirects: Skip when `RTD_TOKEN` is empty

### DIFF
--- a/.github/workflows/sync-rtd-redirects.yaml
+++ b/.github/workflows/sync-rtd-redirects.yaml
@@ -29,6 +29,7 @@ on:
 
 jobs:
   sync:
+    if: secrets.RTD_TOKEN != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Description of proposed changes

RTD redirects can only be synced with a valid RTD_TOKEN. If it is an empty string, it must be invalid. Ideally, making the secret required would catch all invalid token errors, however an empty string still passes the requirement. This job-level condition is the next best thing.

When called with an empty token, the workflow will still be triggered as configured but the job will be skipped instead of failing due to an invalid RTD token.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass (but they don't test this reusable workflow)
- [ ] Skips job on a repo that doesn't have `RTD_TOKEN` available
- [ ] Runs job on a repo with `RTD_TOKEN` available

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
