### PR TITLE
actions/setup-ssh: Direct access to runner machines over Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See also GitHub's [documentation on issue and PR templates](https://docs.github.
 Invoked by our GitHub Actions workflows, including the reusable workflows below.
 
 - [Setup Nextstrain CLI](actions/setup-nextstrain-cli/action.yaml)
+- [Setup SSH](actions/setup-ssh/action.yaml) access to runner machine
 
 See also GitHub's [documentation on creating custom actions](https://docs.github.com/en/actions/creating-actions/about-custom-actions).
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Used to setup other repos.
   ([template](workflow-templates/sync-rtd-redirects.yaml),
   [properties](workflow-templates/sync-rtd-redirects.properties.json))
 
+- Debugging runner: Launch a runner for ad-hoc interactive debugging over SSH using `setup-ssh` above.
+  Only for use in private repositories!
+  ([template](workflow-templates/debugging-runner.yaml),
+  [properties](workflow-templates/debugging-runner.properties.json))
+
 See also GitHub's [documentation on starter workflows](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization).
 
 

--- a/actions/setup-ssh/README.md
+++ b/actions/setup-ssh/README.md
@@ -1,0 +1,71 @@
+# setup-ssh
+
+Sets up SSH access to the current runner machine over a Tailscale network.
+
+The public SSH keys associated with GitHub users are used for authentication
+and authorization.  By default, the users who triggered the initial and current
+workflow runs (which may be different in a re-run) are allowed access.
+
+Tailscale is used to provide direct network access to the runner machine since
+it is behind a NAT and otherwise unreachable.
+
+Note that this does _not_ use [Tailscale
+SSH](https://tailscale.com/kb/1193/tailscale-ssh/), a feature specific to
+Tailscale, but the standard SSH server (e.g. OpenSSH) that already exists on
+the runner machine.  If Tailscale SSH is enabled for your tailnet, then you'll
+need to use [Tailscale ACLs](https://tailscale.com/kb/1018/acls/#tailscale-ssh)
+to manage authentication and authorization instead of SSH keys.
+
+## Inputs
+
+### `tailscale-auth-key`
+
+**Required.**  String.  Tailscale auth key (i.e. from the admin panel); **highly
+recommended to be ephemeral!**  Otherwise, a runner will stick around as a
+registered machine and your Tailscale account's limit will be quickly reached.
+Used in an automated context, it should also be **reusable**, else you'll only
+get one use out of it before needing to update the secret.
+
+### `allowed-users`
+
+Optional.  String.  Comma-separated list of GitHub usernames who are allowed
+access via their public SSH keys.  By default, the users who triggered the
+initial and current workflow runs are allowed.
+
+### `wait-for-continue`
+
+Optional.  Boolean.  Wait for a _~/continue_ file to appear before returning to
+the calling workflow.
+
+## Examples
+
+You might use this action as the last step of a job, running only if the job
+has failed:
+
+```yaml
+- if: failure()
+  uses: nextstrain/.github/actions/setup-ssh@master
+  with:
+    tailscale-auth-key: ${{ secrets.TAILSCALE_AUTH_KEY }}
+    wait-for-continue: true
+```
+
+This would cause a failing job to setup SSH access and then pause, giving you a
+chance to log in and debug the failure.  To resume the job's execution, you'd
+run `touch ~/continue` as the `runner` user (the default user).
+
+## Prior art
+
+Similar actions by other authors also exist:
+
+  - [lhotari/action-upterm](https://github.com/lhotari/action-upterm) uses
+    [upterm](https://upterm.dev/) to cross the NAT.
+
+  - [mxschmitt/action-tmate](https://github.com/mxschmitt/action-tmate) uses
+    [tmate](https://tmate.io) to cross the NAT.
+
+Both cross the NAT using third-party proxy/relay servers, e.g.
+`uptermd.upterm.dev` and `nyc1.tmate.io`.  Third-party proxies can be
+unpalatable for security and privacy reasons, and while both support running
+your own proxy instance, Tailscale allows us not to bother and provides more
+robust security at the same time.

--- a/actions/setup-ssh/action.yaml
+++ b/actions/setup-ssh/action.yaml
@@ -1,0 +1,61 @@
+name: Setup SSH
+description: >-
+  Sets up SSH access to the current runner machine over a Tailscale network.
+
+  Authentication uses the public SSH keys associated with GitHub users.  By
+  default, the users who triggered the initial and current workflow runs are
+  allowed.
+
+inputs:
+  tailscale-auth-key:
+    description: >-
+      Tailscale auth key (i.e. from the admin panel); highly recommended to be
+      ephemeral! Otherwise a runner will stick around and your Tailscale
+      machine limit will be quickly reached.
+    required: true
+
+  allowed-users:
+    description: >-
+      Comma-separated list of GitHub usernames who are allowed access via their
+      public SSH keys.
+    required: false
+    default: "${{ github.triggering_actor }},${{ github.actor }}"
+
+  wait-for-continue:
+    description: >-
+      Wait for a ~/continue file to appear before returning to the calling
+      workflow.
+    required: false
+    default: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup SSH
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        # Setup SSH
+        echo "::group::Debug info"
+          ./debug-info
+        echo "::endgroup::"
+
+        echo "::group::Install Tailscale"
+          curl -fsSL --proto '=https' https://tailscale.com/install.sh | sudo bash
+        echo "::endgroup::"
+
+        echo "::group::Setup Tailscale"
+          ./setup-tailscale "${{ inputs.tailscale-auth-key }}"
+        echo "::endgroup::"
+
+        echo "::group::Setup SSH keys"
+          ./setup-keys "${{ inputs.allowed-users }}"
+        echo "::endgroup::"
+
+        ./connection-info
+
+    - if: inputs.wait-for-continue
+      name: Waiting for ~/continue to appear…
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: ./wait-for-continue

--- a/actions/setup-ssh/connection-info
+++ b/actions/setup-ssh/connection-info
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "SSH ready!  Connect with:"
+echo
+for ip in $(tailscale ip); do
+  echo "    ssh runner@$ip"
+done

--- a/actions/setup-ssh/debug-info
+++ b/actions/setup-ssh/debug-info
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -x
+ip addr
+ip route
+sudo ss -ntulp

--- a/actions/setup-ssh/setup-keys
+++ b/actions/setup-ssh/setup-keys
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+if [[ -z "${1:-}" ]]; then
+    echo "Allowed users are required" >&2
+    exit 1
+fi
+
+mkdir -p ~/.ssh/
+curl -fsSL --proto '=https' "https://github.com/{$1}.keys" \
+    | tee ~/.ssh/authorized_keys

--- a/actions/setup-ssh/setup-tailscale
+++ b/actions/setup-ssh/setup-tailscale
@@ -7,6 +7,14 @@ if [[ -z "${1:-}" ]]; then
     exit 1
 fi
 
+# Restart tailscaled in ephemeral-only mode.  Not required, but nice because it
+# then performs an automatic logout and immediate device removal when it exits,
+# regardless of if the auth key is ephemeral or not.
+#
+# https://tailscale.com/kb/1111/ephemeral-nodes/#can-i-create-an-ephemeral-node-without-an-auth-key
+sudo tee -a /etc/default/tailscaled <<<'FLAGS="--state=mem:"'
+sudo systemctl restart tailscaled
+
 sudo tailscale up \
   --authkey "$1" \
   --hostname "github-runner-$(< /etc/hostname)"

--- a/actions/setup-ssh/setup-tailscale
+++ b/actions/setup-ssh/setup-tailscale
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+if [[ -z "${1:-}" ]]; then
+    echo "Tailscale auth key is required" >&2
+    exit 1
+fi
+
+sudo tailscale up \
+  --authkey "$1" \
+  --hostname "github-runner-$(< /etc/hostname)"

--- a/actions/setup-ssh/wait-for-continue
+++ b/actions/setup-ssh/wait-for-continue
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Waiting for ~/continue to appear…"
+while [[ ! -e ~/continue ]]; do
+    sleep 15
+done

--- a/devel/check-readme
+++ b/devel/check-readme
@@ -2,6 +2,7 @@
 # Check that the README links to all files of interest; a heuristic for keeping
 # us honest about documenting the contents of this repo.
 set -euo pipefail
+shopt -s extglob
 
 delim=$'\x1f' # ASCII unit separator
 
@@ -43,7 +44,8 @@ files-to-ignore() {
     git ls-files \
         README.md \
         devel/check-readme \
-        'images/*'
+        'images/*' \
+        actions/setup-ssh/!(*.yaml)
 }
 
 relative-links() {

--- a/workflow-templates/debugging-runner.properties.json
+++ b/workflow-templates/debugging-runner.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Debugging runner",
+  "description": "Launch a runner for ad-hoc interactive debugging over SSH using our setup-ssh action. Only for use in private repositories!"
+}

--- a/workflow-templates/debugging-runner.yaml
+++ b/workflow-templates/debugging-runner.yaml
@@ -1,0 +1,39 @@
+name: Debugging runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      tailscale-auth-key:
+        description: >-
+          Tailscale auth key to override any TAILSCALE_AUTH_KEY secret; good
+          for single-use, ephemeral auth keys.
+
+          As a non-secret input, this key is vulnerable to a timing attack!
+          Someone who can observe the dispatched workflow run's inputs and use
+          the auth key before the workflow can will be able to join your
+          tailnet.  As such, it's recommended that you only use this workflow
+          in private repos where all users are trusted.
+        type: string
+        required: false
+        default: ""
+
+      allowed-users:
+        description: >-
+          Comma-separated list of GitHub usernames who are allowed access via their
+          public SSH keys.  Defaults to the user who triggers the workflow run.
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  ssh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # XXX TODO: change to @master once the actions/setup-ssh branch is merged
+      - uses: nextstrain/.github/actions/setup-ssh@actions/setup-ssh
+        with:
+          tailscale-auth-key: ${{ inputs.tailscale-auth-key || secrets.TAILSCALE_AUTH_KEY }}
+          allowed-users: ${{ inputs.allowed-users || github.triggering_actor }}
+          wait-for-continue: true


### PR DESCRIPTION
Useful for debugging issues with GitHub Actions workflows, particularly in cases when similar commands work on your machine but not the runner machines.

See also [the README](https://github.com/nextstrain/.github/blob/actions/setup-ssh/actions/setup-ssh/README.md).

### Related issue(s)

- https://github.com/nextstrain/private/pull/72

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Manual testing
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
