### PR TITLE
Add actions/run-nextstrain-build-on-aws-batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Invoked by our GitHub Actions workflows, including the reusable workflows below.
   ([README](actions/setup-ssh/README.md))
 - [Setup debugger](actions/setup-debugger/action.yaml) for interactive debugging of workflow jobs
   ([README](actions/setup-debugger/README.md))
+- [Run Nextstrain build on AWS Batch](actions/run-nextstrain-build-on-aws-batch/action.yaml)
 
 See also GitHub's [documentation on creating custom actions](https://docs.github.com/en/actions/creating-actions/about-custom-actions).
 
@@ -81,6 +82,10 @@ Used to setup other repos.
   Only for use in private repositories!
   ([template](workflow-templates/debugging-runner.yaml),
   [properties](workflow-templates/debugging-runner.properties.json))
+
+- Run Nextstrain build on AWS Batch
+  ([template](workflow-templates/run-nextstrain-build-on-aws-batch.yaml),
+  [properties](workflow-templates/run-nextstrain-build-on-aws-batch.properties.json))
 
 See also GitHub's [documentation on starter workflows](https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization).
 

--- a/actions/run-nextstrain-build-on-aws-batch/action.yaml
+++ b/actions/run-nextstrain-build-on-aws-batch/action.yaml
@@ -1,0 +1,68 @@
+name: Run Nextstrain build on AWS Batch
+description: >-
+  This GitHub Actions action is intended to be called by workflows in our other
+  repos when they need to run a nextstrain build on AWS Batch.
+
+inputs:
+  runtime-envvar-names:
+    description: >-
+      A list of environment variable names for environment variables that
+      should be passed to the build. The envvar names should be separated by
+      a space, e.g. "GITHUB_RUN_ID SLACK_TOKEN SLACK_CHANNELS"
+    type: string
+    required: false
+
+  cpus:
+    description: >-
+      Number of CPUs/cores/threads/jobs to utilize at once.
+      Will be passed to the `--cpus` option for `nextstrain build` and the
+      `--cores` option for Snakemake.
+    type: number
+    default: 4
+    required: false
+
+  memory:
+    description: >-
+      Amount of memory to make available to the build. Passed to the
+      `--memory` option for `nextstrain build`.
+    type: string
+    required: false
+
+  build-args:
+    description: >-
+      Additional command-line arguments to pass to `nextstrain build` after
+      the build directory (e.g. to Snakemake).
+    type: string
+    default: ""
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+    - name: Creating env.d
+      shell: bash
+      run: |
+        "$GITHUB_ACTION_PATH"/write-envdir env.d \
+          ${{ inputs.runtime-envvar-names }}
+
+    - name: Launch build on AWS Batch
+      shell: bash
+      run: |
+        nextstrain build \
+          --aws-batch \
+          --detach \
+          --no-download \
+          --cpus ${{ inputs.cpus }} \
+          --memory ${{ inputs.memory }} \
+          --exec env \
+          . \
+            envdir env.d snakemake \
+              --cores ${{ inputs.cpus }} \
+              ${{ inputs.build-args }} \
+        | tee >(tail -n4 >> "$GITHUB_STEP_SUMMARY")
+      env:
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ env.NEXTSTRAIN_DOCKER_IMAGE }}
+        AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/actions/run-nextstrain-build-on-aws-batch/action.yaml
+++ b/actions/run-nextstrain-build-on-aws-batch/action.yaml
@@ -7,8 +7,15 @@ inputs:
   runtime-envvar-names:
     description: >-
       A list of environment variable names for environment variables that
-      should be passed to the build. The envvar names should be separated by
-      a space, e.g. "GITHUB_RUN_ID SLACK_TOKEN SLACK_CHANNELS"
+      should be passed to the build's runtime. The environment variables that
+      the Nextstrain CLI automatically forwards to the runtime do not need to be
+      listed here. See the list of environment variables that are auto-forwarded in
+      the Nextstrain CLI repo (https://github.com/nextstrain/cli/blob/master/nextstrain/cli/hostenv.py)
+
+      The environment variables can be any environment variable specified at
+      any level (workflow, job, or step) of the workflow using it.
+      The environment variable names should be separated by a space,
+      e.g. "GITHUB_RUN_ID SLACK_TOKEN SLACK_CHANNELS"
     type: string
     required: false
 
@@ -16,7 +23,8 @@ inputs:
     description: >-
       Number of CPUs/cores/threads/jobs to utilize at once.
       Will be passed to the `--cpus` option for `nextstrain build` and the
-      `--cores` option for Snakemake.
+      `--cores` option for Snakemake. See `nextstrain build` docs for more details:
+      https://docs.nextstrain.org/projects/cli/page/commands/build/
     type: number
     default: 4
     required: false
@@ -25,13 +33,15 @@ inputs:
     description: >-
       Amount of memory to make available to the build. Passed to the
       `--memory` option for `nextstrain build`.
+      See `nextstrain build` docs for more details:
+      https://docs.nextstrain.org/projects/cli/page/commands/build/
     type: string
     required: false
 
   build-args:
     description: >-
       Additional command-line arguments to pass to `nextstrain build` after
-      the build directory (e.g. to Snakemake).
+      the build directory (i.e. additional arguments for Snakemake).
     type: string
     default: ""
     required: false

--- a/actions/run-nextstrain-build-on-aws-batch/write-envdir
+++ b/actions/run-nextstrain-build-on-aws-batch/write-envdir
@@ -1,0 +1,22 @@
+#!/bin/bash
+# usage: write-envdir <envdir> [[var1 [var2 [var3 […]]]]
+#
+# Writes the current value for each environment variable name given into the
+# directory <envdir>, one file per variable.  Creates <envdir> if it doesn't
+# already exist.
+#
+# Originally written by @tsibley, copied unmodified from the ncov-ingest repo:
+# https://github.com/nextstrain/ncov-ingest/blob/2a8f5bb4419998d5e3e13c97ebd03a1780ea47c2/bin/write-envdir
+#
+set -eou pipefail
+
+dir="${1:?no envdir path}"
+shift
+
+mkdir -pv "$dir"
+cd "$dir"
+
+for name in "$@"; do
+    echo "${!name}" > "$name"
+    echo "Wrote $dir/$name"
+done

--- a/devel/check-readme
+++ b/devel/check-readme
@@ -48,7 +48,8 @@ files-to-ignore() {
         'images/*' \
         actions/setup-ssh/!(*.yaml|README.md) \
         actions/setup-debugger/!(*.yaml|README.md) \
-        actions/shellcheck/!(*.yaml|README.md)
+        actions/shellcheck/!(*.yaml|README.md) \
+        actions/run-nextstrain-build-on-aws-batch/!(*.yaml|README.md)
 }
 
 relative-links() {

--- a/workflow-templates/run-nextstrain-build-on-aws-batch.properties.json
+++ b/workflow-templates/run-nextstrain-build-on-aws-batch.properties.json
@@ -1,0 +1,4 @@
+{
+  "name": "Run Nextstrain build on AWS Batch",
+  "description": "Starter workflow for setting up Nextstrain builds that need to run on AWS Batch."
+}

--- a/workflow-templates/run-nextstrain-build-on-aws-batch.yaml
+++ b/workflow-templates/run-nextstrain-build-on-aws-batch.yaml
@@ -1,0 +1,28 @@
+name: Run Nextstrain build on AWS Batch
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Specific starter image to use for the build. Will override the default image for `nextstrain build`."
+        required: false
+        type: string
+
+jobs:
+  deploy-build-to-aws-batch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nextstrain/.github/actions/run-nextstrain-build-on-aws-batch@master
+        with:
+          runtime-envvar-names: "GITHUB_RUN_ID PAT_GITHUB_DISPATCH SLACK_CHANNELS SLACK_TOKEN"
+        env:
+          NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # Not auto-forwarded to builds, variable names must be passed via runtime-envvar-names
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          PAT_GITHUB_DISPATCH: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
+          SLACK_CHANNELS: slack-channel-name
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+


### PR DESCRIPTION
### Description of proposed changes

Creates a custom action to run Nextstrain builds on AWS Batch so that we can centralize and standardize how our pathogen repos set up these builds. Motivated by the latest hiccup with the Snakemake upgrade that required fixes across multiple pathogen repos.¹

I decided to make it a composite action instead of a reusable workflow to allow for per-repo custom steps such as setting up trial configs for trial builds² and to be able to use the `GITHUB_ACTION_PATH` to access the shared write-envdir script.

¹ https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1681328249848399 
² https://github.com/nextstrain/ncov/blob/4c5fc8f484cb7310b1039f5f8e847dad34fe4774/.github/workflows/rebuild-gisaid.yml#L38-L48

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] See [trial](https://github.com/nextstrain/seasonal-flu/actions/runs/4897723596) in seasonal flu 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
