### PR TITLE
pathogen-repo-ci: Support a continue-on-error pass thru

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,13 @@ jobs:
     with:
       repo: nextstrain/zika-tutorial
 
+  test-pathogen-repo-ci-failure:
+    uses: ./.github/workflows/pathogen-repo-ci.yaml
+    with:
+      repo: nextstrain/zika-tutorial
+      build-args: __BOGUS_BUILD_TARGET__
+      continue-on-error: true
+
   test-docs-ci-conda:
     uses: ./.github/workflows/docs-ci.yaml
     with:

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -44,6 +44,13 @@ on:
         default: ""
         required: false
 
+      continue-on-error:
+        description: >-
+          Pass thru for <https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error>.
+        type: boolean
+        default: false
+        required: false
+
 permissions:
   contents: read
   packages: read
@@ -51,6 +58,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.continue-on-error }}
     steps:
       # Log in, if possible, to docker.io (Docker Hub), since authenticated
       # requests get higher rate limits (e.g. for image pulls).  Our org-level


### PR DESCRIPTION
Allows calling workflows to succeed even if the job in this called workflow fails.  This is a workaround for the calling working being unable to specify continue-on-error itself.¹

Related-to: <https://github.com/nextstrain/docker-base/pull/148>

¹ <https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
