### PR TITLE
pathogen-repo-ci: Avoid the secret-check step before docker.io login

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/pathogen-repo-ci.yaml
     with:
       repo: nextstrain/zika
+    secrets: inherit
 
   test-pathogen-repo-ci-no-example-data:
     uses: ./.github/workflows/pathogen-repo-ci.yaml

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -66,14 +66,12 @@ jobs:
       # repos on GitHub but only available here to this reusable workflow when
       # called with "secrets: inherit".  On Docker Hub, the token is granted
       # "public read-only" access.
-      - id: DOCKER_TOKEN_PUBLIC_READ_ONLY
-        name: Check if DOCKER_TOKEN_PUBLIC_READ_ONLY secret is available
+      #
+      # The secrets context is not allowed in "if:" conditions, so we must
+      # launder it thru env.
+      - if: env.token-available == 'true'
         env:
-          DOCKER_TOKEN_PUBLIC_READ_ONLY: ${{ secrets.DOCKER_TOKEN_PUBLIC_READ_ONLY }}
-        run: |
-          tee -a "$GITHUB_OUTPUT" <<<available=${DOCKER_TOKEN_PUBLIC_READ_ONLY:+yes}
-
-      - if: steps.DOCKER_TOKEN_PUBLIC_READ_ONLY.outputs.available == 'yes'
+          token-available: ${{ secrets.DOCKER_TOKEN_PUBLIC_READ_ONLY != '' }}
         name: Log in to docker.io
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
@victorlin pointed out¹ that we could launder access to the secrets context thru the step env context without the need for an extra step.

I avoid putting the secret itself into the environment (which only increases its potential visibility) and put only its presence/absence instead.

¹ <https://github.com/nextstrain/.github/pull/38#discussion_r1190281387>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
