### PR TITLE
pathogen-repo-ci: set build matrix to `fail-fast:false`

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -104,6 +104,7 @@ jobs:
   build:
     needs: configuration
     strategy:
+      fail-fast: false
       matrix:
         runtime: ${{ fromJSON(needs.configuration.outputs.runtimes) }}
     name: build (${{ matrix.runtime }})


### PR DESCRIPTION
### Description of proposed changes

Prevents individual runtime failures from interfering with other runtime builds.

Motivated by seasonal-flu CI failure in conda runtime that canceled the job in docker runtime.¹

¹ https://github.com/nextstrain/seasonal-flu/actions/runs/4961494826

### Related issue(s)

Follow up of https://github.com/nextstrain/.github/pull/42

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
