### PR TITLE
Setup nextstrain cli update

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -221,7 +221,7 @@ jobs:
       # future changes to setup-nextstrain-cli.
       #
       #   -trs, 28 April 2022
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@29b00885dff495824a12d95d709c03d3891cc12d
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@e8e1f3213711d8c4b5022f7c29d3eb8ee3f46b4b
         with:
           runtime: ${{ matrix.runtime }}
           # Consider parameterizing the Python version. -trs, 1 April 2022

--- a/actions/setup-nextstrain-cli/action.yaml
+++ b/actions/setup-nextstrain-cli/action.yaml
@@ -8,7 +8,7 @@ description: >-
   repos when they need a working copy of the Nextstrain CLI (the `nextstrain`
   program) installed and don't particularly care about the exact Python
   environment in which its installed.
-  
+
   For example, this is typically the case when the workflow's primary step
   invokes `nextstrain build` to run a build in a container runtime (locally via
   Docker or remotely via AWS Batch).  Workflows that are more complex (e.g.
@@ -64,6 +64,9 @@ runs:
       shell: bash
       env:
         runtime: ${{ inputs.runtime }}
+
+    - run: nextstrain update
+      shell: bash
 
     - run: nextstrain version --verbose
       shell: bash


### PR DESCRIPTION
## Description of proposed changes

There's a weird issue with the Conda runtime where the inital setup
uses an older version.¹ Do an update of the default runtime after setup
to ensure we are using the latest version.

We could remove this extra step after we rework `nextstrain setup` to
use the same logic as `nextstrain update`.

¹ https://github.com/nextstrain/monkeypox/issues/177

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
