### PR TITLE
setup-nextstrain-cli: allow nextstrain update to continue-on-error

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -221,7 +221,7 @@ jobs:
       # future changes to setup-nextstrain-cli.
       #
       #   -trs, 28 April 2022
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@e8e1f3213711d8c4b5022f7c29d3eb8ee3f46b4b
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@1fbb3f2e3bf29374d2706f720f65d4025853a89a
         with:
           runtime: ${{ matrix.runtime }}
           # Consider parameterizing the Python version. -trs, 1 April 2022

--- a/actions/setup-nextstrain-cli/action.yaml
+++ b/actions/setup-nextstrain-cli/action.yaml
@@ -67,6 +67,7 @@ runs:
 
     - run: nextstrain update
       shell: bash
+      continue-on-error: true
 
     - run: nextstrain version --verbose
       shell: bash


### PR DESCRIPTION
## Description of proposed changes

I missed in https://github.com/nextstrain/.github/pull/48 that the command `nextstrain update` will exit with error for aws-batch and ambient runtimes. Instead of maintaining a list of runtime to run the update command, just allow it to continue-on-error.

I [found this error](https://github.com/nextstrain/forecasts-ncov/actions/runs/6089488339/job/16522370819#step:4:272) in separate work to update forecasts-ncov to use the pathogen-repo-build workflow with the aws-batch runtime.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
