### PR TITLE
pathogen-repo-build: update AWS Batch job id matching

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -212,7 +212,7 @@ jobs:
         name: Get AWS Batch job id
         id: aws-batch
         run: |
-          echo "AWS_BATCH_JOB_ID=$(tail -n1 build.log | sed -nE 's/.+attach ([-a-f0-9]+).+/\1/p')" >> "$GITHUB_ENV"
+          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" >> "$GITHUB_ENV"
 
       - if: env.AWS_BATCH_JOB_ID
         name: Generate AWS Batch summary


### PR DESCRIPTION
## Description of proposed changes

Previous pattern expected the AWS Batch job id to be in the example re-attaching command that is only output by the Nextstrain CLI when running the job with the `--detach` flag.

This checks for the AWS Batch job id in the stage output from the CLI immediately after the job was successfully submitted to AWS Batch.¹ This output exists regardless of the detachment status.

¹ https://github.com/nextstrain/cli/blob/3c93e87c2ac6bdd1b6a913070f709067b29a6cc1/nextstrain/cli/runner/aws_batch/__init__.py#L258

## Related issue(s)

Resolves https://github.com/nextstrain/.github/issues/50

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
