### PR TITLE
setup-nextstrain-cli: Use a standalone installation instead of Pip/PyPI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,15 @@ on:
 
 jobs:
   test-setup-nextstrain-cli:
-    runs-on: ubuntu-latest
+    name: test-setup-nextstrain-cli (os=${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-nextstrain-cli

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -220,12 +220,15 @@ jobs:
       # For now, update the hardcoded ref (e.g. @90af34…) below when you make
       # future changes to setup-nextstrain-cli.
       #
+      # [ Update 16 Feb 2024: We solved this for pathogen-repo-build.yaml, but
+      #   because it required a new permission on the GitHub tokens (id-token:
+      #   write) we decided not to update this workflow (yet?) to use the same
+      #   approach. -trs ]
+      #
       #   -trs, 28 April 2022
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@585ce0dde7fda2a82f7ef9054fbb95d2eb21a610
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@c1191de9d5e1a30e91d70b0fd1041d97ed1b2496
         with:
           runtime: ${{ matrix.runtime }}
-          # Consider parameterizing the Python version. -trs, 1 April 2022
-          python-version: "3.7"
 
       - name: Copy example data
         run: |

--- a/actions/setup-nextstrain-cli/action.yaml
+++ b/actions/setup-nextstrain-cli/action.yaml
@@ -29,9 +29,12 @@ inputs:
   runtime:
     description: >-
       Nextstrain runtime to configure and set as the default, as a string
-      understood by `nextstrain setup`.  Defaults to "docker".
+      understood by `nextstrain setup`.  Defaults to "docker" on Linux and
+      "conda" on macOS (where, on GitHub Actions, Docker isn't supported).  On
+      Windows, no runtime is set up by default: GitHub Actions runners can't run
+      Linux containers via WSL2 and our Conda runtime doesn't support Windows.
     type: string
-    default: docker
+    default: ${{ runner.os == 'Linux' && 'docker' || runner.os == 'macOS' && 'conda' || '' }}
     required: false
 
   python-version:
@@ -60,7 +63,8 @@ runs:
     - run: nextstrain version
       shell: bash
 
-    - run: nextstrain setup --set-default "$runtime"
+    - if: inputs.runtime
+      run: nextstrain setup --set-default "$runtime"
       shell: bash
       env:
         runtime: ${{ inputs.runtime }}

--- a/actions/setup-nextstrain-cli/action.yaml
+++ b/actions/setup-nextstrain-cli/action.yaml
@@ -37,28 +37,49 @@ inputs:
     default: ${{ runner.os == 'Linux' && 'docker' || runner.os == 'macOS' && 'conda' || '' }}
     required: false
 
+  # XXX TODO: Remove this in coordination with existing callers.  Callers must
+  # stop specifying it before we remove it here in order to not break.  I've
+  # audited all of our internal usages¹ of this action to check that they don't
+  # rely on the setup-python call and prepped those usages for the removal of
+  # this input.  There are also many external usages², mostly existing in forks
+  # of our repos.
+  #   -trs, 13 Feb 2024
+  #
+  # ¹ <https://github.com/search?q=org%3Anextstrain+%2Fsetup-nextstrain-cli%40master%2F+%28path%3A*.yaml+OR+path%3A*.yml%29&type=code&p=1>
+  # ² <https://github.com/search?q=%28NOT+org%3Anextstrain%29+%2Fsetup-nextstrain-cli%40master%2F+%28path%3A*.yaml+OR+path%3A*.yml%29&type=code&p=1>
+  #
   python-version:
     description: >-
-      Version of Python to use for Nextstrain CLI, as a string understood by
-      actions/setup-python.  Defaults to "3.9".
+      Do not use.  Deprecated and retained (for now) only for backwards
+      compatibility with existing callers.  Will be removed in the future, at
+      which point any callers that still specify a value will break.
     type: string
-    default: "3.9"
+    default: ""
     required: false
 
 runs:
   using: composite
   steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "${{ inputs.python-version }}"
-
-    - run: python3 -m pip install --upgrade pip setuptools wheel
-      shell: bash
-
-    - run: python3 -m pip install --upgrade nextstrain-cli"$version"
-      shell: bash
+    - if: runner.os != 'Windows'
+      run: |
+        curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/"$OS" | bash
       env:
-        version: ${{ inputs.cli-version }}
+        OS: ${{ runner.os == 'Linux' && 'linux' || runner.os == 'macOS' && 'mac' || '' }}
+        VERSION: ${{ inputs.cli-version }}
+        DESTINATION: ${{ runner.temp }}/nextstrain-cli
+      shell: bash
+
+    - if: runner.os == 'Windows'
+      run: Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
+      env:
+        VERSION: ${{ inputs.cli-version }}
+        DESTINATION: ${{ runner.temp }}/nextstrain-cli
+      shell: pwsh
+
+    - run: echo "$DESTINATION" | tee -a "$GITHUB_PATH"
+      env:
+        DESTINATION: ${{ runner.temp }}/nextstrain-cli
+      shell: bash
 
     - run: nextstrain version
       shell: bash


### PR DESCRIPTION
Simplifies and speeds up installation. Aligns with our recommended installation used by many users and many of ourselves. Drops the baggage of setting up a Python install as a side-effect. Discussed on Slack a while back.¹

In order to continue supporting PEP 440/508 (i.e. Pip-style) version range constraints in the cli-version input, I added support for those to the https://nextstrain.org/cli/download/... endpoint.²

I've audited all existing callsites I could find, internally and externally, for transitive reliance on the setup-python step. None seemed to rely upon it, so it's now gone. See also the added comment about removing the python-version input.

¹ <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1694627907115309>
² <https://github.com/nextstrain/nextstrain.org/pull/797>


# Todo

- [x] Audit all existing callers for transitive reliance on `setup-python`
- [x] Remove `python-version` and `setup-python`
- [x] Test in CI on other platforms? currently CI here only calls on Linux.
- [x] Extend nextstrain.org endpoints to support version range specs, [c.f.](https://gist.github.com/tsibley/7386e83651eb8b0956fa426d117da9ed) (https://github.com/nextstrain/nextstrain.org/pull/797)

# Checklist

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
