### PR TITLE
feat(pathogen-repo-ci): allow configuration of workflow root

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -63,6 +63,14 @@ on:
           - conda
         required: false
 
+      workflow-root:
+        description: >-
+          Path to the root of the Snakemake workflow filder to run CI on.
+          Defaults to the root of the workflow repo.
+        type: string
+        default: ${{ github.workspace }}
+        required: false
+
       artifact-name:
         description: >-
           Name to use for build results artifact uploaded at the end of the
@@ -228,6 +236,7 @@ jobs:
           python-version: "3.7"
 
       - name: Copy example data
+        working-directory: ${{ inputs.workflow-root }}
         run: |
           if [[ -d example_data ]]; then
             mkdir -p data/
@@ -237,14 +246,17 @@ jobs:
           fi
 
       - run: nextstrain build . ${{ inputs.build-args }}
+        working-directory: ${{ inputs.workflow-root }}
 
       - if: always()
         uses: actions/upload-artifact@v3
+        env:
+          workdir: ${{ inputs.workflow-root }}
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.runtime }}
           path: |
-            auspice/
-            results/
-            benchmarks/
-            logs/
-            .snakemake/log/
+            $workdir/auspice/
+            $workdir/results/
+            $workdir/benchmarks/
+            $workdir/logs/
+            $workdir/.snakemake/log/

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -65,7 +65,7 @@ on:
 
       workflow-root:
         description: >-
-          Path to the root of the Snakemake workflow filder to run CI on.
+          Path to the root of the workflow folder (e.g. one that contains a Snakefile) to run CI on.
           Defaults to the root of the workflow repo.
         type: string
         default: ${{ github.workspace }}


### PR DESCRIPTION
Current `pathogen-repo-ci` seems to assume that we don't need to customize workdir in `nextstrain build .`, i.e. we can't set `nextstrain build foobar`.

Our nextstrain/pathogen-repo-template, however, puts the main workflow in a folder. So we should add that feature.

See https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1695664810319929 for discussion

### Testing

It works: https://github.com/nextstrain/monkeypox/actions/runs/6303654582/job/17113366921