### PR TITLE
Run nextstrain update on conda runtime only

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -229,7 +229,7 @@ jobs:
       # future changes to setup-nextstrain-cli.
       #
       #   -trs, 28 April 2022
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@1fbb3f2e3bf29374d2706f720f65d4025853a89a
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@4366771cea2482d31395ad9b5d351b950daa798d
         with:
           runtime: ${{ matrix.runtime }}
           # Consider parameterizing the Python version. -trs, 1 April 2022

--- a/actions/setup-nextstrain-cli/action.yaml
+++ b/actions/setup-nextstrain-cli/action.yaml
@@ -65,9 +65,10 @@ runs:
       env:
         runtime: ${{ inputs.runtime }}
 
-    - run: nextstrain update
+    # TODO: Remove this once https://github.com/nextstrain/cli/issues/318 is resolved.
+    - if: inputs.runtime == 'conda'
+      run: nextstrain update
       shell: bash
-      continue-on-error: true
 
     - run: nextstrain version --verbose
       shell: bash


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This was added as a workaround for the conda runtime only, though that reasoning is not clear without digging into commit messages and GitHub comments.

This makes that more clear, and also removes the need to continue-on-error for runtimes unsupported by nextstrain update.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Prompted by https://github.com/nextstrain/.github/pull/49#issuecomment-1734310921

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] `nextstrain update` [runs for conda](https://github.com/nextstrain/.github/actions/runs/6305062655/job/17117727280#step:6:1523) and [not for docker](https://github.com/nextstrain/.github/actions/runs/6305062655/job/17117727129#step:6:362)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
