### PR TITLE
Allow `pathogen-repo-ci` to run workflow in subdir via `build-dir` arg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,13 @@ jobs:
     with:
       repo: nextstrain/zika-tutorial
 
+  test-pathogen-repo-ci-with-build-dir:
+    uses: ./.github/workflows/pathogen-repo-ci.yaml
+    with:
+      repo: nextstrain/monkeypox
+      build-dir: phylogenetic
+      artifact-name: mpox-phylogenetic
+
   test-pathogen-repo-ci-failure:
     uses: ./.github/workflows/pathogen-repo-ci.yaml
     with:

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -63,6 +63,16 @@ on:
           - conda
         required: false
 
+      build-dir:
+        description: >-
+          The directory used for `nextstrain build`.
+          If provided, example data should be in an `example_data` directory
+          relative to this directory.
+          Defaults to the root of the repository.
+        type: string
+        default: "."
+        required: false
+
       artifact-name:
         description: >-
           Name to use for build results artifact uploaded at the end of the
@@ -94,12 +104,20 @@ jobs:
       - id: inputs
         env:
           runtimes: ${{ inputs.runtimes }}
+          build_dir: ${{ inputs.build-dir }}
         shell: bash
         run: |
           runtimes="$(yq --output-format=json --indent=0 . <<<"$runtimes")"
           echo runtimes="$runtimes" | tee -a "$GITHUB_OUTPUT"
+
+          # Remove potential trailing slash and set default to current directory
+          build_dir="${build_dir%/}"
+          build_dir="${build_dir:-'.'}"
+          echo build_dir="$build_dir" | tee -a "$GITHUB_OUTPUT"
+
     outputs:
       runtimes: ${{ steps.inputs.outputs.runtimes }}
+      build_dir: ${{ steps.inputs.outputs.build_dir }}
 
   build:
     needs: configuration
@@ -228,6 +246,7 @@ jobs:
           python-version: "3.7"
 
       - name: Copy example data
+        working-directory: ${{ needs.configuration.outputs.build_dir }}
         run: |
           if [[ -d example_data ]]; then
             mkdir -p data/
@@ -237,14 +256,15 @@ jobs:
           fi
 
       - run: nextstrain build . ${{ inputs.build-args }}
+        working-directory: ${{ needs.configuration.outputs.build_dir }}
 
       - if: always()
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.runtime }}
           path: |
-            auspice/
-            results/
-            benchmarks/
-            logs/
-            .snakemake/log/
+            ${{ needs.configuration.outputs.build_dir }}/auspice/
+            ${{ needs.configuration.outputs.build_dir }}/results/
+            ${{ needs.configuration.outputs.build_dir }}/benchmarks/
+            ${{ needs.configuration.outputs.build_dir }}/logs/
+            ${{ needs.configuration.outputs.build_dir }}/.snakemake/log/


### PR DESCRIPTION
## Description of proposed changes

I'm trialling out putting our main auspice-producing workflow in a folder of a pathogen repo (this is what's currently suggested by our pathogen-repo-template).

This is currently not supported by `pathogen-repo-ci` as there's an implicit assumption that the root of the workflow is in the root of the repo.

In this PR I add support for specifying the workflow directory through an argument passed to pathogen-repo-ci.

Changes are backwards compatible as the default is set to what we previously used: `.`

Prior attempt: https://github.com/nextstrain/.github/pull/57#discussion_r1336389847 this had a bug and so I reverted it.

Now the bug has been addressed. See test run: https://github.com/nextstrain/monkeypox/actions/runs/6330482320/job/17192978189#step:9:17

With the way the argument is used, the `build-dir` argument _must not_ end in trailing slash. This is mentioned in the documentation of the argument.