### PR TITLE
pathogen-repo-build: always generate AWS Batch Job ID & summary

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -281,7 +281,7 @@ jobs:
         name: Get AWS Batch job id
         id: aws-batch
         run: |
-          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" >> "$GITHUB_ENV"
+          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" | tee -a "$GITHUB_ENV"
       - if: ${{ always() && env.AWS_BATCH_JOB_ID }}
         name: Generate AWS Batch summary
         run: |

--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -275,12 +275,14 @@ jobs:
           set -x
 
           eval "$NEXTSTRAIN_BUILD_COMMAND" |& tee build.log
-      - if: ${{ inputs.runtime == 'aws-batch' }}
+      # Attempt to get the AWS Batch ID even if the run build command failed
+      # as long as the runtime is `aws-batch` and the `build.log` file exists
+      - if: ${{ always() && inputs.runtime == 'aws-batch' && hashFiles('build.log') != '' }}
         name: Get AWS Batch job id
         id: aws-batch
         run: |
           echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" >> "$GITHUB_ENV"
-      - if: env.AWS_BATCH_JOB_ID
+      - if: ${{ always() && env.AWS_BATCH_JOB_ID }}
         name: Generate AWS Batch summary
         run: |
           "$NEXTSTRAIN_GITHUB_DIR"/bin/interpolate-env < "$NEXTSTRAIN_GITHUB_DIR"/text-templates/attach-aws-batch.md \

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -248,7 +248,7 @@ jobs:
         name: Get AWS Batch job id
         id: aws-batch
         run: |
-          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" >> "$GITHUB_ENV"
+          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" | tee -a "$GITHUB_ENV"
 
       - if: ${{ always() && env.AWS_BATCH_JOB_ID }}
         name: Generate AWS Batch summary

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -242,13 +242,15 @@ jobs:
 
           eval "$NEXTSTRAIN_BUILD_COMMAND" |& tee build.log
 
-      - if: ${{ inputs.runtime == 'aws-batch' }}
+      # Attempt to get the AWS Batch ID even if the run build command failed
+      # as long as the runtime is `aws-batch` and the `build.log` file exists
+      - if: ${{ always() && inputs.runtime == 'aws-batch' && hashFiles('build.log') != '' }}
         name: Get AWS Batch job id
         id: aws-batch
         run: |
           echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < build.log)" >> "$GITHUB_ENV"
 
-      - if: env.AWS_BATCH_JOB_ID
+      - if: ${{ always() && env.AWS_BATCH_JOB_ID }}
         name: Generate AWS Batch summary
         run: |
           "$NEXTSTRAIN_GITHUB_DIR"/bin/interpolate-env < "$NEXTSTRAIN_GITHUB_DIR"/text-templates/attach-aws-batch.md \


### PR DESCRIPTION
## Description of proposed changes

Ran into a workflow run where the `run-build` step failed and the job exited without generating the AWS Batch Job ID or summary.¹

This commit updates the condition to always try to generate the AWS Batch ID as long as the runtime is `aws-batch` and the `build.log` file exists. This then allows the workflow to always generate the AWS Batch Job summary even if the build failed.

¹ https://github.com/nextstrain/forecasts-ncov/actions/runs/8203385071

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test workflow](https://github.com/nextstrain/.github/actions/runs/8209099097) where build fails but still outputs AWS Batch summary

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
