### PR TITLE
pathogen-repo-build: Bump minimum Nextstrain CLI version to 8.3.0

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -266,7 +266,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
       - name: Run build via ${{ inputs.runtime }}
         env:
@@ -341,7 +341,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -398,7 +398,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -456,7 +456,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -514,7 +514,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -595,7 +595,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
       - id: cancel
         name: Cancel AWS Batch job

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -232,7 +232,7 @@ jobs:
         name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=7.4.0"
+          cli-version: ">=8.3.0"
           runtime: ${{ inputs.runtime }}
 
       - name: Run build via ${{ inputs.runtime }}


### PR DESCRIPTION
Ensure support for pathogen repo builds with the latest changes:

* support for workflows in subdirectories¹
* support for setting runtime envvars via `NEXTSTRAIN_RUNTIME_ENVDIRS`²

¹ <https://github.com/nextstrain/cli/releases/tag/8.2.0> 
² <https://github.com/nextstrain/cli/releases/tag/8.3.0>

## Related issue(s)

Related to https://github.com/nextstrain/private/issues/96#issuecomment-2078310852

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
