### PR TITLE
Remove intentional failure test #48 #58

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,14 +40,6 @@ jobs:
       repo: nextstrain/zika-tutorial
       artifact-name: outputs-test-pathogen-repo-ci-no-example-data
 
-  test-pathogen-repo-ci-failure:
-    uses: ./.github/workflows/pathogen-repo-ci.yaml
-    with:
-      repo: nextstrain/zika-tutorial
-      artifact-name: outputs-test-pathogen-repo-ci-failure
-      build-args: __BOGUS_BUILD_TARGET__
-      continue-on-error: true
-
   test-docs-ci-conda:
     uses: ./.github/workflows/docs-ci.yaml
     with:


### PR DESCRIPTION
Per Jover,

> This is testing the workaround for continue-on-error added in #40
> works as expected. Reading through that discussion again, @tsibley
> had noted that we can eventually remove the test.

> The workaround has been working for a ~year now, so I think it's 
> safe to remove the test now!

