### PR TITLE
Update `pathogen-repo-ci` to better support CI [#63]

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -6,6 +6,14 @@ name: CI
 on:
   workflow_call:
     inputs:
+      build-target:
+        description: >-
+          The build directory to provide as the first argument to
+          `nextstrain build`.
+        type: string
+        default: "."
+        required: false
+
       build-args:
         description: >-
           Additional command-line arguments to pass to `nextstrain build` after
@@ -72,6 +80,26 @@ on:
           If you're invoking this workflow multiple times from the same calling
           workflow, you should set this.  Otherwise, the default of "outputs"
           is probably fine.
+        type: string
+        default: outputs
+        required: false
+
+      download-previous-artifact:
+        description: >-
+          Boolean indicating whether to try to download a build artifact from
+          a previous stage.
+        type: boolean
+        default: false
+        required: false
+
+      previous-artifact-name:
+        description: >-
+          Name to use for previous artifact file, when downloading the artifact
+          from a previous stage.
+
+          If you're downloading the previous stage's artifact, you should set
+          `artifact-name` to something in that step's config, then use that same
+          name here.
         type: string
         default: outputs
         required: false
@@ -200,6 +228,13 @@ jobs:
         with:
           repository: ${{ inputs.repo }}
 
+      - name: Download previous step artifact
+        if: inputs.download-previous-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.previous-artifact-name }}-${{ matrix.runtime }}
+          path: ${{ inputs.previous-artifact-name }}
+
       # XXX TODO: It would be better for this to call setup-nextstrain-cli
       # using the same ref that this workflow was called with (e.g. if this
       # workflow was invoked by the caller workflow with @foo than we invoke
@@ -239,15 +274,15 @@ jobs:
             echo No example data to copy.
           fi
 
-      - run: nextstrain build . ${{ inputs.build-args }}
+      - run: nextstrain build ${{ inputs.build-target }} ${{ inputs.build-args }}
 
       - if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.runtime }}
           path: |
-            auspice/
-            results/
-            benchmarks/
-            logs/
-            .snakemake/log/
+            ${{ inputs.build-target }}/auspice/
+            ${{ inputs.build-target }}/results/
+            ${{ inputs.build-target }}/benchmarks/
+            ${{ inputs.build-target }}/logs/
+            ${{ inputs.build-target }}/.snakemake/log/


### PR DESCRIPTION
This adds the following features to the `pathogen-repo-ci` workflow:

* defines a `build-target` argument that will get passed to `nextstrain build` as a target directory — this allows the targeting of sub-dir based workflows, which was the main original issue in #63
* defines arguments (`download-previous-artifact`, `previous-artifact-name`) and a conditional step (`Dowload previous step artifact`) to support the downloading of the build artifact from a previous step to allow testing of later steps in a complete pathogen repo build

This combination of features was all that was needed to support [a CI workflow for
`seasonal-cov`](https://github.com/nextstrain/seasonal-cov/pull/11) that:

1. runs an ingest workflow for a subset of the regular build data
2. uploads an artifact with the ingest output
3. downloads that artifact into a phylogenetic workflow
4. runs the phylogenetic workflow for the same subset of data

## Description of proposed changes

This is an attempt to address the issues in #63 , which I also ended up running in to while trying to add CI to the `seasonal-cov` repo. I made a copy of this workflow into the `seasonal-cov` repo, and made the minimum viable set of changes needed to support the CI work I wanted to add. 

## Related issue(s)

[seasonal-cov/#8](https://github.com/nextstrain/seasonal-cov/issues/8)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
