### PR TITLE
pathogen-repo-build: Only write AWS_SESSION_TOKEN into the envdir if it's not empty

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -287,7 +287,7 @@ jobs:
           "$NEXTSTRAIN_GITHUB_DIR"/bin/write-envdir "$NEXTSTRAIN_RUNTIME_ENVDIR" \
             AWS_ACCESS_KEY_ID \
             AWS_SECRET_ACCESS_KEY \
-            AWS_SESSION_TOKEN
+            ${AWS_SESSION_TOKEN:+AWS_SESSION_TOKEN}
         # This will overwrite the runtime AWS credential envvars configured above
         # so if the build is using the aws-batch runtime, the Nextstrain CLI will
         # have access to the AWS Batch session credentials

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -256,7 +256,7 @@ jobs:
           "$NEXTSTRAIN_GITHUB_DIR"/bin/write-envdir "$NEXTSTRAIN_RUNTIME_ENVDIR" \
             AWS_ACCESS_KEY_ID \
             AWS_SECRET_ACCESS_KEY \
-            AWS_SESSION_TOKEN
+            ${AWS_SESSION_TOKEN:+AWS_SESSION_TOKEN}
 
     # This will overwrite the runtime AWS credential envvars configured above
     # so if the build is using the aws-batch runtime, the Nextstrain CLI will


### PR DESCRIPTION
No AWS_SESSION_TOKEN is present when callers provide static IAM user credentials via AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. `write-envdir` requires all env vars given are defined.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
