### PR TITLE
Make `pathogen-repo-ci` fail when config is missing or no builds are attempted

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,12 +30,6 @@ jobs:
       artifact-name: outputs-test-pathogen-repo-ci
     secrets: inherit
 
-  test-pathogen-repo-ci-no-example-data:
-    uses: ./.github/workflows/pathogen-repo-ci.yaml
-    with:
-      repo: nextstrain/zika-tutorial
-      artifact-name: outputs-test-pathogen-repo-ci-no-example-data
-
   test-docs-ci-conda:
     uses: ./.github/workflows/docs-ci.yaml
     with:

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -238,6 +238,13 @@ jobs:
           ref: ${{ needs.workflow-context.outputs.sha }}
           path: ${{ env.NEXTSTRAIN_GITHUB_DIR }}
 
+      - name: Verify nextstrain-pathogen.yaml file
+        run: >
+          if [[ ! -f nextstrain-pathogen.yaml ]]; then
+            echo "To use this workflow, there must be a 'nextstrain-pathogen.yaml' file present in the repository root";
+            exit 1;
+          fi
+
       - name: Set up Nextstrain runtime ${{ matrix.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:

--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -252,6 +252,7 @@ jobs:
           runtime: ${{ matrix.runtime }}
 
       - name: Run ingest
+        id: ingest
         uses: ./.git/nextstrain/.github/actions/run-nextstrain-ci-build
         with:
           directory: ingest
@@ -259,6 +260,7 @@ jobs:
           artifact-name: ${{ inputs.artifact-name }}
 
       - name: Run phylogenetic
+        id: phylogenetic
         uses: ./.git/nextstrain/.github/actions/run-nextstrain-ci-build
         with:
           directory: phylogenetic
@@ -266,8 +268,19 @@ jobs:
           artifact-name: ${{ inputs.artifact-name }}
 
       - name: Run nextclade
+        id: nextclade
         uses: ./.git/nextstrain/.github/actions/run-nextstrain-ci-build
         with:
           directory: nextclade
           runtime: ${{ matrix.runtime }}
           artifact-name: ${{ inputs.artifact-name }}
+
+      - name: Verify a workflow ran
+        run: |
+          # shellcheck disable=SC2129,SC2242
+
+          # if we see at least one success, we're good
+          echo "INGEST ATTEMPTED=${{ steps.ingest.outputs.run-attempted }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "PHYLOGENETIC ATTEMPTED=${{ steps.phylogenetic.outputs.run-attempted }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "NEXTCLADE ATTEMPTED=${{ steps.nextclade.outputs.run-attempted }}" >> "$GITHUB_STEP_SUMMARY"
+          exit ${{ contains(steps.*.outputs.run-attempted, 'true') && '0' || '1' }}

--- a/actions/run-nextstrain-ci-build/action.yaml
+++ b/actions/run-nextstrain-ci-build/action.yaml
@@ -33,12 +33,12 @@ runs:
       env:
         DIR: ${{ inputs.directory }}
       run: |
-        if [[ -f nextstrain-pathogen.yaml && -f "$DIR"/Snakefile && -f "$DIR"/build-configs/ci/config.yaml ]]; then
+        if [[ -f "$DIR"/Snakefile && -f "$DIR"/build-configs/ci/config.yaml ]]; then
           nextstrain check-setup ${{ inputs.runtime }} --set-default
           nextstrain build "$DIR" --configfile build-configs/ci/config.yaml
         else
           echo "Skipping $DIR build due to one or more missing files."
-          for i in nextstrain-pathogen.yaml "$DIR"/Snakefile "$DIR"/build-configs/ci/config.yaml; do
+          for i in "$DIR"/Snakefile "$DIR"/build-configs/ci/config.yaml; do
             [[ -f $i ]] || echo missing "$i"
           done
         fi

--- a/actions/run-nextstrain-ci-build/action.yaml
+++ b/actions/run-nextstrain-ci-build/action.yaml
@@ -26,6 +26,15 @@ inputs:
     type: string
     required: true
 
+outputs:
+  run-attempted:
+    description: >-
+      Boolean indicating if the build step was _attempted_.
+
+      N.b., this does not indicate if the build step *succeeded*, only
+      that the requirements were met to attempt to run it.
+    value: ${{ steps.run-build.outputs.run-attempted }}
+
 runs:
   using: "composite"
   steps:
@@ -34,9 +43,13 @@ runs:
         DIR: ${{ inputs.directory }}
       run: |
         if [[ -f "$DIR"/Snakefile && -f "$DIR"/build-configs/ci/config.yaml ]]; then
+          echo "run-attempted=true" >> "$GITHUB_OUTPUT"
+
           nextstrain check-setup ${{ inputs.runtime }} --set-default
           nextstrain build "$DIR" --configfile build-configs/ci/config.yaml
         else
+          echo "run-attempted=false" >> "$GITHUB_OUTPUT"
+
           echo "Skipping $DIR build due to one or more missing files."
           for i in "$DIR"/Snakefile "$DIR"/build-configs/ci/config.yaml; do
             [[ -f $i ]] || echo missing "$i"


### PR DESCRIPTION
## Description of proposed changes

Make the CI fail if it doesn't try to run at least one build step, as that's an indication that somebody is trying to use "modern" `pathogen-repo-ci` on an un-modernized pathogen repo (or there's some other grievous misconfig happening).  

## Related issue(s)

#92 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Clean up CI bits in this repo that break
- [x] Checks pass
- [x] Verify a repo without `pathogen-nextstrain.yaml` fails as expected [proof](https://github.com/nextstrain/seasonal-cov/actions/runs/9469661700/job/26089377134#step:8:12)
- [x] Verify a repo that has `pathogen-nexstrain.yaml` but lacking required files for all build steps fails as expected [proof](https://github.com/nextstrain/seasonal-cov/actions/runs/9469995788/job/26089927906)
- [x] Verify a repo that has one step that attempts to run succeeds as expected [proof](https://github.com/nextstrain/seasonal-cov/actions/runs/9470059750/job/26090113771)
- [x] Verify a repo that runs two steps still succeeds as expected [proof](https://github.com/nextstrain/seasonal-cov/actions/runs/9470094934/job/26090223884)
- [ ] ~Verify a repo that runs all three steps still succeeds as expected~ — skipping because I don't think there's a repo handy with a `nextclade` build that's also using pathogen-repo-ci(?)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
