### PR TITLE
pathogen-repo-ci: Keep running even if one of the pathogen workflows fails

### DIFF
--- a/.github/workflows/pathogen-repo-ci.yaml
+++ b/.github/workflows/pathogen-repo-ci.yaml
@@ -286,16 +286,18 @@ jobs:
         if: hashFiles('ingest/Snakefile') && hashFiles('ingest/build-configs/ci/config.yaml')
         id: ingest
         run: nextstrain build ingest --configfile build-configs/ci/config.yaml
+        continue-on-error: true
       - name: Run phylogenetic
         if: hashFiles('phylogenetic/Snakefile') && hashFiles('phylogenetic/build-configs/ci/config.yaml')
         id: phylogenetic
         run: nextstrain build phylogenetic --configfile build-configs/ci/config.yaml
+        continue-on-error: true
       - name: Run nextclade
         if: hashFiles('nextclade/Snakefile') && hashFiles('nextclade/build-configs/ci/config.yaml')
         id: nextclade
         run: nextstrain build nextclade --configfile build-configs/ci/config.yaml
-      - if: always()
-        uses: actions/upload-artifact@v4
+        continue-on-error: true
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.runtime }}
           if-no-files-found: ignore
@@ -320,11 +322,13 @@ jobs:
             nextclade/results/
       - name: Verify a workflow ran
         env:
-          ingest: ${{ steps.ingest.conclusion }}
-          phylogenetic: ${{ steps.phylogenetic.conclusion }}
-          nextclade: ${{ steps.nextclade.conclusion }}
+          # "outcome" is success/failure/cancelled/skipped _before_
+          # "continue-on-error" is applied to calculate "conclusion"
+          ingest: ${{ steps.ingest.outcome }}
+          phylogenetic: ${{ steps.phylogenetic.outcome }}
+          nextclade: ${{ steps.nextclade.outcome }}
         run: |
-          # Show step conclusions in job logs…
+          # Show step outcomes in job logs…
           echo "ingest        $ingest"
           echo "phylogenetic  $phylogenetic"
           echo "nextclade     $nextclade"
@@ -332,6 +336,11 @@ jobs:
           # …and also in the workflow summary.
           "$NEXTSTRAIN_GITHUB_DIR"/bin/interpolate-env < "$NEXTSTRAIN_GITHUB_DIR"/text-templates/pathogen-repo-ci.md > "$GITHUB_STEP_SUMMARY"
 
-          # Assert status; if we see at least one attempt, regardless of
-          # success/failure, we're good.
-          [[ $ingest != skipped || $phylogenetic != skipped || $nextclade != skipped ]]
+          # Assert status; we're good if we see at least one success and the
+          # rest are success or skipped.
+          [[
+               ($ingest == success || $phylogenetic == success || $nextclade == success)
+            && ($ingest       == success || $ingest       == skipped)
+            && ($phylogenetic == success || $phylogenetic == skipped)
+            && ($nextclade    == success || $nextclade    == skipped)
+          ]]

--- a/.github/workflows/pathogen-repo-ci.yaml.in
+++ b/.github/workflows/pathogen-repo-ci.yaml.in
@@ -263,19 +263,21 @@ jobs:
         if: hashFiles('ingest/Snakefile') && hashFiles('ingest/build-configs/ci/config.yaml')
         id: ingest
         run: nextstrain build ingest --configfile build-configs/ci/config.yaml
+        continue-on-error: true
 
       - name: Run phylogenetic
         if: hashFiles('phylogenetic/Snakefile') && hashFiles('phylogenetic/build-configs/ci/config.yaml')
         id: phylogenetic
         run: nextstrain build phylogenetic --configfile build-configs/ci/config.yaml
+        continue-on-error: true
 
       - name: Run nextclade
         if: hashFiles('nextclade/Snakefile') && hashFiles('nextclade/build-configs/ci/config.yaml')
         id: nextclade
         run: nextstrain build nextclade --configfile build-configs/ci/config.yaml
+        continue-on-error: true
 
-      - if: always()
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.runtime }}
           if-no-files-found: ignore
@@ -301,11 +303,13 @@ jobs:
 
       - name: Verify a workflow ran
         env:
-          ingest: ${{ steps.ingest.conclusion }}
-          phylogenetic: ${{ steps.phylogenetic.conclusion }}
-          nextclade: ${{ steps.nextclade.conclusion }}
+          # "outcome" is success/failure/cancelled/skipped _before_
+          # "continue-on-error" is applied to calculate "conclusion"
+          ingest: ${{ steps.ingest.outcome }}
+          phylogenetic: ${{ steps.phylogenetic.outcome }}
+          nextclade: ${{ steps.nextclade.outcome }}
         run: |
-          # Show step conclusions in job logs…
+          # Show step outcomes in job logs…
           echo "ingest        $ingest"
           echo "phylogenetic  $phylogenetic"
           echo "nextclade     $nextclade"
@@ -313,6 +317,11 @@ jobs:
           # …and also in the workflow summary.
           "$NEXTSTRAIN_GITHUB_DIR"/bin/interpolate-env < "$NEXTSTRAIN_GITHUB_DIR"/text-templates/pathogen-repo-ci.md > "$GITHUB_STEP_SUMMARY"
 
-          # Assert status; if we see at least one attempt, regardless of
-          # success/failure, we're good.
-          [[ $ingest != skipped || $phylogenetic != skipped || $nextclade != skipped ]]
+          # Assert status; we're good if we see at least one success and the
+          # rest are success or skipped.
+          [[
+               ($ingest == success || $phylogenetic == success || $nextclade == success)
+            && ($ingest       == success || $ingest       == skipped)
+            && ($phylogenetic == success || $phylogenetic == skipped)
+            && ($nextclade    == success || $nextclade    == skipped)
+          ]]

--- a/text-templates/pathogen-repo-ci.md
+++ b/text-templates/pathogen-repo-ci.md
@@ -1,4 +1,4 @@
-| workflow      | conclusion      |
+| workflow      | outcome         |
 | ------------- | --------------- |
 | ingest        | ${ingest}       |
 | phylogenetic  | ${phylogenetic} |


### PR DESCRIPTION
In testing it's helpful to report all test results even in the face of an early failure to reduce the chances of playing whack-a-mole with unreported failures once when you fix the first failure.  For example, we want to know if the phylogenetic workflow fails even when the ingest workflow run before it fails.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test that failure behaviour works as expected ([no valid workflows](https://github.com/nextstrain/.github/actions/runs/9511668562), [two valid workflows](https://github.com/nextstrain/.github/actions/runs/9511672955), [one broken workflow](https://github.com/nextstrain/.github/actions/runs/9523126166))

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
