### PR TITLE
Add `make linkcheck` step, to check external links [#29]

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -68,6 +68,9 @@ jobs:
       - run: make ${{ inputs.make-target }}
         working-directory: ${{ inputs.docs-directory }}
 
+      - run: make linkcheck
+        working-directory: ${{ inputs.docs-directory }}
+
   build-pip:
     if: inputs.pip-install-target != ''
     runs-on: ubuntu-latest
@@ -81,4 +84,7 @@ jobs:
       - run: pip list
 
       - run: make ${{ inputs.make-target }}
+        working-directory: ${{ inputs.docs-directory }}
+
+      - run: make linkcheck
         working-directory: ${{ inputs.docs-directory }}


### PR DESCRIPTION
## Description of proposed changes

Adds a `make linkcheck` step to the Sphinx CI.

Note that this blocks on the various PRs attached to nextstrain/docs.nextstrain.org#14 — those PRs should be merged before this one.

Update to add: I realized this workflow is used by more than `docs.nextstrain.org`, so before this can be merged, the following repos need to be audited for broken links:

- [x] Audit augur -- nextstrain/augur#1570
- [x] Audit auspice --  nextstrain/auspice#1808
- [x] Audit cli -- nextstrain/cli#389
- [x] Audit ncov -- nextstrain/ncov#1137


<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

Closes #29 
nextstrain/docs.nextstrain.org#14

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
