### PR TITLE
actions/setup-debugger: Pause for 1 second after interrupting an exec...

### DIFF
--- a/actions/setup-debugger/.gitignore
+++ b/actions/setup-debugger/.gitignore
@@ -1,0 +1,1 @@
+/bpftrace

--- a/actions/setup-debugger/debugger
+++ b/actions/setup-debugger/debugger
@@ -36,7 +36,9 @@ main() {
 
     while <& "$interceptor" IFS=$'\x1f' read -r pid comm exe; do
         echo -n "process $pid ($comm) exec of $exe "
+        sleep 1
         set-vars
+        echo -n "($argv0 ${args[*]}) "
 
         if should-interact; then
             echo "[intercepted by debugger]" >> /proc/"$pid"/fd/2

--- a/devel/check-readme
+++ b/devel/check-readme
@@ -43,6 +43,7 @@ files-of-interest() {
 files-to-ignore() {
     git ls-files \
         .gitignore \
+        '**/.gitignore' \
         README.md \
         'images/*' \
         actions/setup-ssh/!(*.yaml|README.md) \


### PR DESCRIPTION
...to allow /proc/$pid/cmdline to have contents. It consistently seemed to be empty (?) on GitHub Actions runners without this brief sleep. This hacky solution worked in the moment, and so it's what I'm committing since its tested. There are likely better solutions that don't rely on sleeping, like checking for the property we care about (e.g. does /proc/$pid/cmdline have contents?), but I didn't try those and so don't want to commit something that doesn't work.

Log the full argv for an easier time debugging the debugger next go around.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
