### PR TITLE
Split `make linkcheck` out into a distinct job [#106]

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -68,9 +68,6 @@ jobs:
       - run: make ${{ inputs.make-target }}
         working-directory: ${{ inputs.docs-directory }}
 
-      - run: make linkcheck
-        working-directory: ${{ inputs.docs-directory }}
-
   build-pip:
     if: inputs.pip-install-target != ''
     runs-on: ubuntu-latest
@@ -86,5 +83,17 @@ jobs:
       - run: make ${{ inputs.make-target }}
         working-directory: ${{ inputs.docs-directory }}
 
-      - run: make linkcheck
+  linkcheck:
+    if: inputs.pip-install-target != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo }}
+
+      - run: pip install '${{ inputs.pip-install-target }}'
+
+      - id: linkcheck
+        run: make linkcheck
         working-directory: ${{ inputs.docs-directory }}
+        continue-on-error: true


### PR DESCRIPTION
## Description of proposed changes

Split `make linkcheck` into a distinct job, with `continue-on-error: true`, so that transient failures don't show as CI fails. 
## Related issue(s)

Closes #106 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
