### PR TITLE
Use a single build job

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -48,8 +48,7 @@ env:
   SPHINXOPTS: -n -W --keep-going
 
 jobs:
-  build-conda:
-    if: inputs.environment-file != ''
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -59,29 +58,19 @@ jobs:
         with:
           repository: ${{ inputs.repo }}
 
-      - uses: conda-incubator/setup-miniconda@v3
+      # Set up environment with Conda
+      - if: inputs.environment-file != ''
+        uses: conda-incubator/setup-miniconda@v3
         with:
           environment-file: ${{ inputs.environment-file }}
+      - if: inputs.environment-file != ''
+        run: conda list
 
-      - run: conda list
-
-      - run: make ${{ inputs.make-target }}
-        working-directory: ${{ inputs.docs-directory }}
-
-      - run: make linkcheck
-        working-directory: ${{ inputs.docs-directory }}
-
-  build-pip:
-    if: inputs.pip-install-target != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repo }}
-
-      - run: pip install '${{ inputs.pip-install-target }}'
-
-      - run: pip list
+      # Set up environment with pip
+      - if: inputs.pip-install-target != ''
+        run: pip install '${{ inputs.pip-install-target }}'
+      - if: inputs.pip-install-target != ''
+        run: pip list
 
       - run: make ${{ inputs.make-target }}
         working-directory: ${{ inputs.docs-directory }}


### PR DESCRIPTION
## Description of proposed changes

The number of steps that are shared between the two jobs now exceeds the number of steps that differ. In this case, it seems more maintainable to use one job with per-step conditions for environment setup.

This should also look nicer downstream - previously there was always one job that was skipped since they are meant to be mutually exclusive.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
