### PR TITLE
docs-ci: Don't error on timeouts

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -46,6 +46,7 @@ env:
   # --keep-going: find all warnings
   # https://www.sphinx-doc.org/en/master/man/sphinx-build.html
   SPHINXOPTS: -n -W --keep-going
+  BUILDDIR: _build
 
 jobs:
   build:
@@ -75,5 +76,16 @@ jobs:
       - run: make ${{ inputs.make-target }}
         working-directory: ${{ inputs.docs-directory }}
 
-      - run: make linkcheck
+      # Ignore the exit code, results will be checked in the next step
+      - run: make linkcheck || true
+        working-directory: ${{ inputs.docs-directory }}
+
+      - name: Check for broken links
+        run: |
+          broken_links=$(jq 'select(.status == "broken")' "$BUILDDIR/linkcheck/output.json")
+          if [ -n "$broken_links" ]; then
+            echo "Broken links found:"
+            echo "$broken_links"
+            exit 1
+          fi
         working-directory: ${{ inputs.docs-directory }}


### PR DESCRIPTION
## Description of proposed changes

linkcheck [errors on both timeouts and broken links](https://github.com/sphinx-doc/sphinx/blob/2f1d775dfda9e4f81dfff6cfbe9edf7731e32a97/sphinx/builders/linkcheck.py#L82-L83). We only want the CI job to fail on broken links since timeouts are most likely transient.

## Related issue(s)

- #106

## Checklist

- [x] Checks pass
- [x] Merge at least one of:
    - https://github.com/nextstrain/docs.nextstrain.org/pull/232
    - https://github.com/nextstrain/augur/pull/1650
- [x] docs-ci fails on 12d5ab47631758465623c9edffccdff210c2bf3f as expected
- [ ] Merge base PR #109

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
