### PR TITLE
docs-ci: Check environment-file and pip-install-target inputs

### DIFF
--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -55,6 +55,17 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
+      - name: Check inputs
+        if: (inputs.environment-file == '' && inputs.pip-install-target == '') ||
+            (inputs.environment-file != '' && inputs.pip-install-target != '')
+        run: |
+          cat <<~~
+          This workflow requires one (and only one) of the following inputs:
+          - environment-file
+          - pip-install-target
+          ~~
+          exit 1
+
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.repo }}


### PR DESCRIPTION
## Description of proposed changes

These are marked as optional in the inputs block. There was an implicit assumption that it's required to have one of the inputs but not both. This can't be encoded in the inputs block so check the values as the very first step.

## Related issue(s)

- Follow-up to https://github.com/nextstrain/.github/pull/109#discussion_r1803510032

## Checklist

- [x] docs-ci checks pass
- [x] docs-ci checks fail on 733c2347235047dadfef33b3fd09aa01b7f848ac as expected
- [x] Drop 733c2347235047dadfef33b3fd09aa01b7f848ac before merging

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
