### PR TITLE
Keep workflows enabled

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -16,7 +16,7 @@ jobs:
       actions: write
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
-    name: enable-workflow (${{ matrix.repo }}/${{ matrix.workflow }})
+    name: "${{ matrix.repo }}:${{ matrix.workflow }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -1,0 +1,58 @@
+# This workflow is intended to keep scheduled GH Action workflows enabled
+# as a work-around for scheduled workflows being automatically disabled when
+# no repository activity has occurred in 60 days.
+name: Keep workflows enabled
+
+on:
+  schedule:
+    # Scheduled to run at 4pm UTC (8am PST) on the first day of the month
+    - cron: '0 16 1 * *'
+
+  workflow_dispatch:
+
+jobs:
+  enable-workflow:
+    permissions:
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    name: enable-workflow (${{ matrix.repo }}/${{ matrix.workflow }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { repo: .github,         workflow: keep-workflows-enabled.yaml }
+          - { repo: augur,           workflow: ci.yaml }
+          - { repo: avian-flu,       workflow: ingest-to-phylogenetic-ncbi.yaml }
+          - { repo: cli,             workflow: ci.yaml }
+          - { repo: cli,             workflow: standalone-installers.yaml }
+          - { repo: conda-base,      workflow: installation.yaml }
+          - { repo: dengue,          workflow: ingest-to-phylogenetic.yaml }
+          - { repo: forecasts-ncov,  workflow: update-ncov-case-counts.yaml }
+          - { repo: lassa,           workflow: ci.yaml }
+          - { repo: lassa,           workflow: ingest-to-phylogenetic.yaml }
+          - { repo: measles,         workflow: ingest-to-phylogenetic.yaml }
+          - { repo: mpox,            workflow: fetch-and-ingest.yaml }
+          - { repo: ncov,            workflow: rebuild-100k.yml }
+          - { repo: ncov-ingest,     workflow: fetch-and-ingest-genbank-master.yml }
+          - { repo: ncov-ingest,     workflow: fetch-and-ingest-gisaid-master.yml }
+          - { repo: nextstrain.org,  workflow: index-resources.yml }
+          - { repo: nextstrain.org,  workflow: remind-to-promote.yml }
+          - { repo: nipah,           workflow: ingest-to-phylogenetic.yaml }
+          - { repo: oropouche,       workflow: ingest-to-phylogenetic.yaml }
+          - { repo: rabies,          workflow: ingest-to-phylogenetic.yaml }
+          - { repo: rsv,             workflow: fetch-and-ingest.yaml }
+          - { repo: rsv,             workflow: rebuild.yaml }
+          - { repo: seasonal-cov,    workflow: ingest-to-phylogenetic.yaml }
+          - { repo: status,          workflow: ci.yaml }
+          - { repo: WNV,             workflow: ingest-to-phylogenetic.yaml }
+          - { repo: zika,            workflow: ingest-to-phylogenetic.yaml }
+
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/nextstrain/${{matrix.repo}}/actions/workflows/${{matrix.workflow}}/enable

--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       actions: write
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}
     name: enable-workflow (${{ matrix.repo }}/${{ matrix.workflow }})
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ See also GitHub's [documentation on starter workflows](https://docs.github.com/e
 
 - CI tests for the actions and reusable workflows above
   ([workflow](.github/workflows/ci.yaml))
+- Central workflow to keep all scheduled GH Action workflows enabled
+  ([workflow](.github/workflows/keep-workflows-enabled.yaml))
 
 
 ## Workflow scripts


### PR DESCRIPTION
## Description of proposed changes

Uses the GH API to "enable" scheduled workflows on the first of
every month as a work-around for scheduled workflows being automatically
disabled when no repository activity has occurred in 60 days.

Included all active Nextstrain org GH Action workflows that have the
`schedule` trigger plus this new workflow so it keeps itself enabled.

<https://github.com/search?q=org%3Anextstrain+path%3A.github%2Fworkflows%2F**+schedule&type=code>

## Related issue(s)

Resolves https://github.com/nextstrain/.github/issues/112

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run](https://github.com/nextstrain/.github/actions/runs/12036559030)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
