### PR TITLE
keep-workflows-enabled: Add hmpv

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -29,6 +29,7 @@ jobs:
           - { repo: conda-base,      workflow: installation.yaml }
           - { repo: dengue,          workflow: ingest-to-phylogenetic.yaml }
           - { repo: forecasts-ncov,  workflow: update-ncov-case-counts.yaml }
+          - { repo: hmpv,            workflow: pathogen-repo-build.yml }
           - { repo: lassa,           workflow: ci.yaml }
           - { repo: lassa,           workflow: ingest-to-phylogenetic.yaml }
           - { repo: measles,         workflow: ingest-to-phylogenetic.yaml }


### PR DESCRIPTION
## Description of proposed changes

Noticed that hmpv's "Ingest to phylogenetic" workflow was disabled since 2025-03-10. I've manually re-enabled the workflow and adding it here to ensure the workflow stays enabled even if there's no activity in the repo.

Outside of this PR, I had to add nextstrain/core to the hmpv repo so that nextstrain-bot's GH token had permissions to enable the workflow. 

## Related issue(s)

Resolves <https://github.com/nextstrain/.github/issues/123>

## Checklist

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/.github/actions/runs/13817765881/job/38655334932)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
