### PR TITLE
pathogen-repo-build: Fix extraction of AWS Batch job ids

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -319,7 +319,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
       - name: Run build via ${{ inputs.runtime }}
         env:
@@ -342,7 +342,7 @@ jobs:
         name: Get AWS Batch job id
         id: aws-batch
         run: |
-          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < "$NEXTSTRAIN_BUILD_LOG")" | tee -a "$GITHUB_ENV"
+          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/^AWS Batch Job ID: ([-a-f0-9]+)$/\1/p' < "$NEXTSTRAIN_BUILD_LOG")" | tee -a "$GITHUB_ENV"
       - if: ${{ always() && env.AWS_BATCH_JOB_ID }}
         name: Generate AWS Batch summary
         run: |
@@ -396,7 +396,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -454,7 +454,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -513,7 +513,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -572,7 +572,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
       - id: attach
         name: Attach to AWS Batch job
@@ -654,7 +654,7 @@ jobs:
       - name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
       - id: cancel
         name: Cancel AWS Batch job

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -296,7 +296,7 @@ jobs:
         name: Setup runtime ${{ inputs.runtime }}
         uses: ./.git/nextstrain/.github/actions/setup-nextstrain-cli
         with:
-          cli-version: ">=8.3.0"
+          cli-version: ">=9.0.0"
           runtime: ${{ inputs.runtime }}
 
       - name: Run build via ${{ inputs.runtime }}
@@ -321,7 +321,7 @@ jobs:
         name: Get AWS Batch job id
         id: aws-batch
         run: |
-          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/.+AWS Batch Job ID\:.+ ([-a-f0-9]+)$/\1/p' < "$NEXTSTRAIN_BUILD_LOG")" | tee -a "$GITHUB_ENV"
+          echo "AWS_BATCH_JOB_ID=$(sed -nE 's/^AWS Batch Job ID: ([-a-f0-9]+)$/\1/p' < "$NEXTSTRAIN_BUILD_LOG")" | tee -a "$GITHUB_ENV"
 
       - if: ${{ always() && env.AWS_BATCH_JOB_ID }}
         name: Generate AWS Batch summary


### PR DESCRIPTION
Nextstrain CLI 9.0.0 added an improvement that automatically disables colorized and bolded output when stdout is not a terminal (or when NO_COLOR is set).  This broke our sed pattern which too-stringently expected ANSI escapes (matched by ".+") to surround the "AWS Batch Job ID:" label.

Bump our CLI requirement to 9.0.0 and remove expectation of ANSI escapes from the sed pattern.  We could handle both presence and absence of ANSI escapes, but its simpler to bump to 9.0.0 and expect absence.

In the future, we should stop parsing job logs and add a feature to Nextstrain CLI to directly emit this job id in a more structured way.

Related-to: <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1743179523144269>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
