### PR TITLE
Update keep-workflows-enabled

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -44,11 +44,11 @@ jobs:
           - { repo: rabies,          workflow: ingest-to-phylogenetic.yaml }
           - { repo: rsv,             workflow: fetch-and-ingest.yaml }
           - { repo: rsv,             workflow: rebuild.yaml }
-          - { repo: seasonal-cov,    workflow: ingest-to-phylogenetic.yaml }
+          - { repo: seasonal-cov,    workflow: ingest.yaml }
           - { repo: status,          workflow: ci.yaml }
           - { repo: WNV,             workflow: ingest-to-phylogenetic.yaml }
-          - { repo: yellow-fever,    workflow: ingest-to-phylogenetic.yaml }
-          - { repo: zika,            workflow: ingest-to-phylogenetic.yaml }
+          - { repo: yellow-fever,    workflow: ingest.yaml }
+          - { repo: zika,            workflow: ingest.yaml }
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -34,6 +34,7 @@ jobs:
           - { repo: lassa,           workflow: ingest-to-phylogenetic.yaml }
           - { repo: measles,         workflow: ingest-to-phylogenetic.yaml }
           - { repo: mpox,            workflow: fetch-and-ingest.yaml }
+          - { repo: mumps,           workflow: ingest.yaml }
           - { repo: ncov,            workflow: rebuild-100k.yml }
           - { repo: ncov-ingest,     workflow: fetch-and-ingest-genbank-master.yml }
           - { repo: ncov-ingest,     workflow: fetch-and-ingest-gisaid-master.yml }


### PR DESCRIPTION
## Description of proposed changes

[Today's scheduled run](https://github.com/nextstrain/.github/actions/runs/14778641421) for keep-workflows-enabled failed due to changes in GH Actions for https://github.com/nextstrain/pathogen-repo-guide/issues/25.

Updated the workflows for seasonal-cov, yellow-fever, and zika and added mumps to the list. 

(I should really look into https://github.com/nextstrain/.github/issues/119 to avoid having to do manual updates like this 😅)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [Test run](https://github.com/nextstrain/.github/actions/runs/14780543310)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
