### PR TITLE
keep-workflows-enabled: update `ingest-to-phylogenetic` to `ingest`

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -29,7 +29,7 @@ jobs:
           - { repo: conda-base,      workflow: installation.yaml }
           - { repo: dengue,          workflow: ingest-to-phylogenetic.yaml }
           - { repo: forecasts-ncov,  workflow: update-ncov-case-counts.yaml }
-          - { repo: hmpv,            workflow: pathogen-repo-build.yml }
+          - { repo: hmpv,            workflow: ingest.yaml }
           - { repo: lassa,           workflow: ci.yaml }
           - { repo: lassa,           workflow: ingest-to-phylogenetic.yaml }
           - { repo: measles,         workflow: ingest-to-phylogenetic.yaml }
@@ -40,8 +40,8 @@ jobs:
           - { repo: ncov-ingest,     workflow: fetch-and-ingest-gisaid-master.yml }
           - { repo: nextstrain.org,  workflow: index-resources.yml }
           - { repo: nextstrain.org,  workflow: remind-to-promote.yml }
-          - { repo: nipah,           workflow: ingest-to-phylogenetic.yaml }
-          - { repo: oropouche,       workflow: ingest-to-phylogenetic.yaml }
+          - { repo: nipah,           workflow: ingest.yaml }
+          - { repo: oropouche,       workflow: ingest.yaml }
           - { repo: rabies,          workflow: ingest-to-phylogenetic.yaml }
           - { repo: rsv,             workflow: fetch-and-ingest.yaml }
           - { repo: rsv,             workflow: rebuild.yaml }


### PR DESCRIPTION
## Description of proposed changes

hmpv, nipah, and oropouche have all been updated to scheduling the ingest  workflow according to 

<https://github.com/nextstrain/pathogen-repo-guide/issues/25>


## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [Test run](https://github.com/nextstrain/.github/actions/runs/14913156428)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
