### PR TITLE
pathogen-repo-build: Update `wait-*` job conditionals

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -415,15 +415,9 @@ jobs:
             --attach "$AWS_BATCH_JOB_ID" \
             --detach-on-interrupt \
             --no-download
-    # Allow the workflow to be considered successful even if this job errors
-    # due to cancellation (timing out).  Unfortunately, this doesn't
-    # distinguish between error from cancellation and error from command
-    # failure, so we work around that below.
-    continue-on-error: true
     # Emit a "conclusion" output for the job that's based on the built-in
     # conclusion (success, failure, cancelled) of the "attach" step above.
-    # This is the conclusion we care about for the job since the job's own
-    # "conclusion" is masked/transformed by "continue-on-error: true" above.
+    # This is the conclusion we care about for the job.
     outputs:
       attach-step-conclusion: ${{ steps.attach.conclusion }}
   # Wait for up to another 6 hours (hours 6–12) if the preceding wait-N job
@@ -473,19 +467,13 @@ jobs:
             --attach "$AWS_BATCH_JOB_ID" \
             --detach-on-interrupt \
             --no-download
-    # Allow the workflow to be considered successful even if this job errors
-    # due to cancellation (timing out).  Unfortunately, this doesn't
-    # distinguish between error from cancellation and error from command
-    # failure, so we work around that below.
-    continue-on-error: true
     # Emit a "conclusion" output for the job that's based on the built-in
     # conclusion (success, failure, cancelled) of the "attach" step above.
-    # This is the conclusion we care about for the job since the job's own
-    # "conclusion" is masked/transformed by "continue-on-error: true" above.
+    # This is the conclusion we care about for the job.
     outputs:
       attach-step-conclusion: ${{ steps.attach.conclusion }}
     needs: [wait-1, run-build, workflow-context]
-    if: needs.wait-1.outputs.attach-step-conclusion == 'cancelled'
+    if: ${{ !cancelled() && !failure() && needs.wait-1.outputs.attach-step-conclusion == 'cancelled' }}
   # 12–18 hours
   wait-3:
     runs-on: ubuntu-latest
@@ -532,19 +520,13 @@ jobs:
             --attach "$AWS_BATCH_JOB_ID" \
             --detach-on-interrupt \
             --no-download
-    # Allow the workflow to be considered successful even if this job errors
-    # due to cancellation (timing out).  Unfortunately, this doesn't
-    # distinguish between error from cancellation and error from command
-    # failure, so we work around that below.
-    continue-on-error: true
     # Emit a "conclusion" output for the job that's based on the built-in
     # conclusion (success, failure, cancelled) of the "attach" step above.
-    # This is the conclusion we care about for the job since the job's own
-    # "conclusion" is masked/transformed by "continue-on-error: true" above.
+    # This is the conclusion we care about for the job.
     outputs:
       attach-step-conclusion: ${{ steps.attach.conclusion }}
     needs: [wait-2, run-build, workflow-context]
-    if: needs.wait-2.outputs.attach-step-conclusion == 'cancelled'
+    if: ${{ !cancelled() && !failure() && needs.wait-2.outputs.attach-step-conclusion == 'cancelled' }}
   # 18–24 hours
   wait-4:
     runs-on: ubuntu-latest
@@ -591,23 +573,17 @@ jobs:
             --attach "$AWS_BATCH_JOB_ID" \
             --detach-on-interrupt \
             --no-download
-    # Allow the workflow to be considered successful even if this job errors
-    # due to cancellation (timing out).  Unfortunately, this doesn't
-    # distinguish between error from cancellation and error from command
-    # failure, so we work around that below.
-    continue-on-error: true
     # Emit a "conclusion" output for the job that's based on the built-in
     # conclusion (success, failure, cancelled) of the "attach" step above.
-    # This is the conclusion we care about for the job since the job's own
-    # "conclusion" is masked/transformed by "continue-on-error: true" above.
+    # This is the conclusion we care about for the job.
     outputs:
       attach-step-conclusion: ${{ steps.attach.conclusion }}
     needs: [wait-3, run-build, workflow-context]
-    if: needs.wait-3.outputs.attach-step-conclusion == 'cancelled'
-  # Since the wait-N jobs use "continue-on-error: true" out of necessity (to
-  # avoid failing the whole workflow when they time out and get cancelled), we
-  # use a final job here to succeed or fail the whole workflow based on the
-  # aggregate of their "attach" step conclusions.
+    if: ${{ !cancelled() && !failure() && needs.wait-3.outputs.attach-step-conclusion == 'cancelled' }}
+  # Unfortunately, the overall workflow status will still be "cancelled" if
+  # any of the `wait-N` jobs were cancelled due to timeout. Use a final job here
+  # to track if the whole workflow succeeded based on the aggregate of their
+  # "attach" step conclusions so we can potentially query the final status via the GitHu API
   wait-conclusion:
     needs: [wait-1, wait-2, wait-3, wait-4]
     if: always()

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -380,16 +380,9 @@ jobs:
             --detach-on-interrupt \
             --no-download
 
-    # Allow the workflow to be considered successful even if this job errors
-    # due to cancellation (timing out).  Unfortunately, this doesn't
-    # distinguish between error from cancellation and error from command
-    # failure, so we work around that below.
-    continue-on-error: true
-
     # Emit a "conclusion" output for the job that's based on the built-in
     # conclusion (success, failure, cancelled) of the "attach" step above.
-    # This is the conclusion we care about for the job since the job's own
-    # "conclusion" is masked/transformed by "continue-on-error: true" above.
+    # This is the conclusion we care about for the job.
     outputs:
       attach-step-conclusion: ${{ steps.attach.conclusion }}
 
@@ -398,24 +391,24 @@ jobs:
   wait-2:
     <<: *wait
     needs: [wait-1, run-build, workflow-context]
-    if: needs.wait-1.outputs.attach-step-conclusion == 'cancelled'
+    if: ${{ !cancelled() && !failure() && needs.wait-1.outputs.attach-step-conclusion == 'cancelled' }}
 
   # 12–18 hours
   wait-3:
     <<: *wait
     needs: [wait-2, run-build, workflow-context]
-    if: needs.wait-2.outputs.attach-step-conclusion == 'cancelled'
+    if: ${{ !cancelled() && !failure() && needs.wait-2.outputs.attach-step-conclusion == 'cancelled' }}
 
   # 18–24 hours
   wait-4:
     <<: *wait
     needs: [wait-3, run-build, workflow-context]
-    if: needs.wait-3.outputs.attach-step-conclusion == 'cancelled'
+    if: ${{ !cancelled() && !failure() && needs.wait-3.outputs.attach-step-conclusion == 'cancelled' }}
 
-  # Since the wait-N jobs use "continue-on-error: true" out of necessity (to
-  # avoid failing the whole workflow when they time out and get cancelled), we
-  # use a final job here to succeed or fail the whole workflow based on the
-  # aggregate of their "attach" step conclusions.
+  # Unfortunately, the overall workflow status will still be "cancelled" if
+  # any of the `wait-N` jobs were cancelled due to timeout. Use a final job here
+  # to track if the whole workflow succeeded based on the aggregate of their
+  # "attach" step conclusions so we can potentially query the final status via the GitHu API
   wait-conclusion:
     needs: [wait-1, wait-2, wait-3, wait-4]
     if: always()


### PR DESCRIPTION
## Description of proposed changes

It's unclear to me why this change happened, but setting `continue-on-error: true` no longer masks the cancelled job's result as "successful". The job result is now "cancelled", so the `wait-*` jobs are skipped because the previous conditional depends on a "successful" upstream job.

This change removes `continue-on-error: true` since it no longer serves it's purpose and updates the `wait-*` job conditional to run as long as the workflow was not cancelled, the previous job did not fail, and the previous job conclusion was "cancelled" due to timeout. 

I am keeping the final `wait-conclusion` job as a marker of the workflow success in case we want to query the workflow status via the specific job status via the GitHub API.

## Related issue(s)

Resolves https://github.com/nextstrain/.github/issues/129

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
