### PR TITLE
keep-workflows-enabled: Disable all workflows before enabling

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -1,6 +1,9 @@
-# This workflow is intended to keep scheduled GH Action workflows enabled
-# as a work-around for scheduled workflows being automatically disabled when
-# no repository activity has occurred in 60 days.
+# This workflow regularly disables and re-enables scheduled GH Action workflows.
+# Reasons:
+# 1. Ensures that email notifications for scheduled runs are configurable by the
+#    team under nextstrain-bot's account settings.
+# 2. Prevents workflows from being automatically disabled when no repository
+#    activity has occurred in 60 days.
 name: Keep workflows enabled
 
 on:
@@ -62,7 +65,16 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Disable workflow
+        run: |
+          gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/nextstrain/${{matrix.repo}}/actions/workflows/${{matrix.workflow}}/disable
+
+      - name: Enable workflow
+        run: |
           gh api \
           --method PUT \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Description of proposed changes

The last user that enabled a disabled workflow or updated the schedule is the one that "owns" all the future scheduled runs of that workflow and receives any email notifications if configured in the user's settings.¹

This makes nextstrain-bot the owner of all the workflows listed here, not just the ones that were automatically disabled due to inactivity.

¹ https://docs.github.com/en/actions/concepts/workflows-and-actions/notifications-for-workflow-runs

## Related issue(s)

https://github.com/nextstrain/private/issues/194

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass (except for [unrelated failure](https://github.com/nextstrain/augur/issues/1932))
- [x] Post-merge: manually trigger a run: https://github.com/nextstrain/.github/actions/runs/20041844158

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
