### PR TITLE
keep-workflows-enabled: Delay enable API call by 1 second

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -73,6 +73,9 @@ jobs:
           -H "X-GitHub-Api-Version: 2022-11-28" \
           /repos/nextstrain/${{matrix.repo}}/actions/workflows/${{matrix.workflow}}/disable
 
+      - name: Sleep
+        run: sleep 1
+
       - name: Enable workflow
         run: |
           gh api \


### PR DESCRIPTION
## Description of proposed changes

Testing if delaying the enable API call by 1 second would let scheduled workflows to run as expected

<https://github.com/nextstrain/.github/issues/153#issuecomment-3683597394>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass -> Unrelated [linkcheck error](https://github.com/nextstrain/.github/actions/runs/20441260351/job/58734577568#step:10:22)
- [x] [Test run](https://github.com/nextstrain/.github/actions/runs/20441166209)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
