### PR TITLE
keep-workflows-enabled: extend delay to 5s

### DIFF
--- a/.github/workflows/keep-workflows-enabled.yaml
+++ b/.github/workflows/keep-workflows-enabled.yaml
@@ -74,7 +74,7 @@ jobs:
           /repos/nextstrain/${{matrix.repo}}/actions/workflows/${{matrix.workflow}}/disable
 
       - name: Sleep
-        run: sleep 1
+        run: sleep 5
 
       - name: Enable workflow
         run: |


### PR DESCRIPTION

## Description of proposed changes

Follow up to <https://github.com/nextstrain/.github/pull/154>.

Avian-flu workflow did not run as scheduled,¹ so extending the delay to see if it will help with the situation.

¹ <https://github.com/nextstrain/.github/issues/153#issuecomment-3711824738>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run](https://github.com/nextstrain/.github/actions/runs/20727261138)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
