### PR TITLE
workflow-context: Upgrade to v8 of actions/github-script

### DIFF
--- a/actions/workflow-context/action.yaml
+++ b/actions/workflow-context/action.yaml
@@ -38,7 +38,7 @@ runs:
   using: composite
   steps:
     - id: context
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           let idToken = await core.getIDToken();


### PR DESCRIPTION
Squashes Node 20 vs. 24 [warnings](https://github.com/nextstrain/.github/actions/runs/23453091901?pr=164).

## Checklist

- [x] Checks pass