### PR TITLE
pathogen-repo-build: Ensure build.log is uploaded

### DIFF
--- a/.github/workflows/pathogen-repo-build.yaml
+++ b/.github/workflows/pathogen-repo-build.yaml
@@ -332,13 +332,15 @@ jobs:
           # shellcheck disable=SC2154
           set -x
 
+          exit_status=0
           # tee build output to .git/ to avoid
           # https://github.com/nextstrain/.github/issues/77#issuecomment-1998652064
           # After build is complete, move .git/build.log to the working directory
           # so this is kept as an implementation detail
-          eval "$NEXTSTRAIN_BUILD_COMMAND" |& tee .git/"$NEXTSTRAIN_BUILD_LOG"
+          eval "$NEXTSTRAIN_BUILD_COMMAND" |& tee .git/"$NEXTSTRAIN_BUILD_LOG" || exit_status=$?
 
           mv .git/"$NEXTSTRAIN_BUILD_LOG" "$NEXTSTRAIN_BUILD_LOG"
+          exit $exit_status
       # Attempt to get the AWS Batch ID even if the run build command failed
       # as long as the runtime is `aws-batch` and the `NEXTSTRAIN_BUILD_LOG` file exists
       - if: ${{ always() && inputs.runtime == 'aws-batch' && hashFiles(env.NEXTSTRAIN_BUILD_LOG) != '' }}

--- a/.github/workflows/pathogen-repo-build.yaml.in
+++ b/.github/workflows/pathogen-repo-build.yaml.in
@@ -310,13 +310,15 @@ jobs:
           # shellcheck disable=SC2154
           set -x
 
+          exit_status=0
           # tee build output to .git/ to avoid
           # https://github.com/nextstrain/.github/issues/77#issuecomment-1998652064
           # After build is complete, move .git/build.log to the working directory
           # so this is kept as an implementation detail
-          eval "$NEXTSTRAIN_BUILD_COMMAND" |& tee .git/"$NEXTSTRAIN_BUILD_LOG"
+          eval "$NEXTSTRAIN_BUILD_COMMAND" |& tee .git/"$NEXTSTRAIN_BUILD_LOG" || exit_status=$?
 
           mv .git/"$NEXTSTRAIN_BUILD_LOG" "$NEXTSTRAIN_BUILD_LOG"
+          exit $exit_status
 
       # Attempt to get the AWS Batch ID even if the run build command failed
       # as long as the runtime is `aws-batch` and the `NEXTSTRAIN_BUILD_LOG` file exists


### PR DESCRIPTION

## Description of proposed changes

Noticed while debugging workflows that the artifact did not include the expected build log.¹ This is due to the failed workflow exiting immediately before moving the build log to the expected location for the uploaded artifact.

¹ <https://github.com/nextstrain/norovirus/actions/runs/26050724373>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
