### PR TITLE
docs-ci: add input `run-linkcheck`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
       repo: nextstrain/docs.nextstrain.org
       docs-directory: .
       environment-file: conda.yml
+      run-linkcheck: false
 
   test-docs-ci-pip:
     uses: ./.github/workflows/docs-ci.yaml
@@ -43,6 +44,7 @@ jobs:
       repo: nextstrain/augur
       docs-directory: docs/
       pip-install-target: .[dev]
+      run-linkcheck: false
 
   test-pathogen-repo-build:
     permissions:

--- a/.github/workflows/docs-ci.yaml
+++ b/.github/workflows/docs-ci.yaml
@@ -39,6 +39,13 @@ on:
         type: string
         default: html
 
+      run-linkcheck:
+        description: >-
+          Run linkcheck steps
+        type: boolean
+        default: true
+        required: false
+
 env:
   # Used for `make` steps.
   # -n: warn on missing references
@@ -88,10 +95,12 @@ jobs:
         working-directory: ${{ inputs.docs-directory }}
 
       # Ignore the exit code, results will be checked in the next step
-      - run: make linkcheck || true
+      - if: inputs.run-linkcheck
+        run: make linkcheck || true
         working-directory: ${{ inputs.docs-directory }}
 
-      - name: Check for broken links
+      - if: inputs.run-linkcheck
+        name: Check for broken links
         run: |
           broken_links=$(jq 'select(.status == "broken")' "$BUILDDIR/linkcheck/output.json")
           if [ -n "$broken_links" ]; then


### PR DESCRIPTION
## Description of proposed changes

Allow calling workflows to skip linkcheck steps. This will allow our workflows to stop linkcheck on every run to reduce the noise from false positives.

Defaults to true to keep the previous behavior.

## Related issue(s)

Prompted by https://github.com/nextstrain/augur/pull/2002#discussion_r3270453113

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~


### Post-merge

Update workflows to only run linkcheck for scheduled runs ([GH search](https://github.com/search?q=org%3Anextstrain+docs-ci.yaml+%28NOT+repo%3Anextstrain%2F.github%29&type=code))
- [x] https://github.com/nextstrain/auspice/pull/2049
- [x] https://github.com/nextstrain/augur/pull/2004
- [x] https://github.com/nextstrain/docs.nextstrain.org/pull/274
- [x] https://github.com/nextstrain/cli/pull/531
- [x] https://github.com/nextstrain/ncov/pull/1200

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
